### PR TITLE
feat: rebrand from Language Learning to Open Learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# 🌍 Language Learning by Examples
+# 🎓 Open Learn
 
 A modern, static single-page web application for learning any topic through practical examples. Built with Vue 3, this platform features interactive lessons with audio pronunciation, progress tracking, and a clean, responsive interface.
 
 ## ✨ Features
 
-- **📚 Topic-Based Learning**: Organized lessons with sections and examples
-- **🌐 Multi-Language Support**: Learn any topic in your preferred language
-- **🔊 Audio Reading**: Text-to-speech functionality for listening to examples (Web Speech API)
+- **📚 Topic-Based Learning**: Organized lessons with sections and examples for any subject
+- **🌐 Multi-Language Interface**: Learn any topic in your preferred language
+- **🔊 Audio Reading**: Pre-recorded MP3 audio for listening to examples
 - **📊 Progress Tracking**: Mark items as learned with LocalStorage persistence
 - **🌓 Dark Mode**: Toggle between light and dark themes
 - **📱 Responsive Design**: Works seamlessly on desktop and mobile devices
@@ -38,7 +38,7 @@ A modern, static single-page web application for learning any topic through prac
 ```bash
 # Clone the repository
 git clone <repository-url>
-cd language
+cd open-learn
 
 # Install dependencies
 pnpm install
@@ -74,7 +74,7 @@ pnpm test:e2e
 ## 📁 Project Structure
 
 ```
-language/
+open-learn/
 ├── src/
 │   ├── main.js              # Application entry point
 │   ├── App.vue              # Root component with navigation
@@ -82,21 +82,28 @@ language/
 │   ├── router/
 │   │   └── index.js         # Vue Router configuration
 │   ├── views/               # Page components
-│   │   ├── Home.vue         # Language selection
+│   │   ├── Home.vue         # Topic selection
 │   │   ├── LessonsOverview.vue  # Lessons grid
 │   │   ├── LessonDetail.vue     # Lesson viewer
+│   │   ├── LearningItems.vue    # Learning items browser
 │   │   └── Settings.vue     # Settings panel
-│   └── composables/         # Reusable composition functions
-│       ├── useLessons.js    # Lesson loading logic
-│       └── useSettings.js   # Settings persistence
+│   ├── composables/         # Reusable composition functions
+│   │   ├── useLessons.js    # Lesson loading logic
+│   │   ├── useSettings.js   # Settings persistence
+│   │   ├── useProgress.js   # Progress tracking
+│   │   └── useAudio.js      # Audio playback system
+│   └── utils/
+│       └── formatters.js    # Display name formatting
 ├── public/
 │   └── lessons/             # YAML lesson content
-│       ├── index.yaml       # Root index
+│       ├── languages.yaml   # Root index
 │       ├── deutsch/         # German learning content
 │       └── english/         # English learning content
 ├── tests/                   # Test files
 ├── docs/                    # Documentation
-│   └── lesson-schema.md     # YAML schema reference
+│   ├── lesson-schema.md     # YAML schema reference
+│   ├── yaml-schemas.md      # Index file schemas
+│   └── audio-system.md      # Audio system docs
 └── dist/                    # Production build output
 ```
 
@@ -105,14 +112,10 @@ language/
 ### Adding a New Lesson
 
 1. Navigate to the appropriate folder: `public/lessons/<learning>/<teaching>/`
-2. Create a YAML file following the schema (see `docs/lesson-schema.md`)
-3. Add the filename to the topic's `index.yaml`:
-
-```yaml
-lessons:
-  - 01-basics.yaml
-  - 02-your-new-lesson.yaml
-```
+2. Create a new lesson folder: `public/lessons/<learning>/<teaching>/##-lesson-name/`
+3. Create `content.yaml` in the lesson folder following the schema (see `docs/lesson-schema.md`)
+4. Add the folder name to `lessons.yaml`
+5. Optionally generate audio files with `./generate-audio.sh`
 
 ### Lesson Format Example
 
@@ -132,12 +135,12 @@ sections:
           - ["bin", "am", "to be"]
 ```
 
-### Adding a New Language Pair
+### Adding a New Topic
 
 1. Create folder structure: `public/lessons/<learning>/<teaching>/`
-2. Add language to `public/lessons/index.yaml` if needed
-3. Create topic index: `public/lessons/<learning>/index.yaml`
-4. Add lesson files and their index
+2. Add topic to `public/lessons/<learning>/topics.yaml`
+3. Create `lessons.yaml` with lesson folder names
+4. Add lesson folders with `content.yaml` files
 
 For complete schema documentation, see [`docs/lesson-schema.md`](docs/lesson-schema.md).
 
@@ -172,7 +175,7 @@ pnpm build
 
 Push to the `main` branch triggers automatic deployment via GitHub Actions (`.github/workflows/static.yml`).
 
-**Note**: Vite is configured with `base: '/language/'` for subdirectory deployment.
+**Note**: Vite is configured with `base: '/open-learn/'` for subdirectory deployment.
 
 ## 🏗 Architecture
 
@@ -183,16 +186,18 @@ Push to the `main` branch triggers automatic deployment via GitHub Actions (`.gi
 - **Dynamic Routing**: Hash-based routing for static hosting
 
 ### Routes
-- `#/` - Home (language selection)
-- `#/lessons/:learning/:teaching` - Lessons overview
-- `#/lesson/:learning/:teaching/:number` - Lesson detail
+- `#/` - Home (topic selection)
+- `#/:learning/:teaching/lessons` - Lessons overview
+- `#/:learning/:teaching/lesson/:number` - Lesson detail
+- `#/:learning/:teaching/items/:number?` - Learning items
 - `#/settings` - Settings panel
 
 ### Data Flow
-1. Load `lessons/index.yaml` → get available languages
-2. Load `lessons/{lang}/index.yaml` → get topics
-3. Load lesson files dynamically with js-yaml
-4. Render with Vue components
+1. Load `lessons/languages.yaml` → get available interface languages
+2. Load `lessons/{lang}/topics.yaml` → get topics
+3. Load `lessons/{lang}/{topic}/lessons.yaml` → get lesson folders
+4. Load lesson content dynamically with js-yaml
+5. Render with Vue components
 
 ## 🤝 Contributing
 

--- a/docs/audio-system.md
+++ b/docs/audio-system.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The language learning app features a high-quality audio playback system using pre-recorded MP3 files generated with native text-to-speech voices. Audio files are pre-loaded for each lesson and support features like variable playback speed, lock screen controls, and automatic pauses between examples.
+The Open Learn platform features a high-quality audio playback system using pre-recorded MP3 files generated with native text-to-speech voices. Audio files are pre-loaded for each lesson and support features like variable playback speed, lock screen controls, and automatic pauses between examples.
 
 ## Audio Generation
 
-### Script: `generate-lesson-audio.sh`
+### Script: `generate-audio.sh`
 
 This Bash script generates MP3 audio files for all lesson content using macOS `say` command and `ffmpeg`.
 
@@ -199,7 +199,7 @@ Lock screen controls are configured automatically when a lesson loads:
 navigator.mediaSession.metadata = new MediaMetadata({
   title: lessonTitle,
   artist: `Learning ${teaching}`,
-  album: `Language Learning - ${learning}`,
+  album: `Open Learn - ${learning}`,
   artwork: [
     { src: artworkUrl, sizes: '512x512', type: 'image/svg+xml' }
   ]

--- a/docs/lesson-plan-template.md
+++ b/docs/lesson-plan-template.md
@@ -1,12 +1,12 @@
 # Universal Lesson Plan Template
 
-This document provides a suggested learning progression and lesson schema template that can be used for teaching any language pair.
+This document provides a suggested learning progression and lesson schema template. While the example below focuses on language learning, the same structure can be adapted for any topic on the Open Learn platform.
 
 ## Overview
 
-A complete language learning curriculum typically consists of **30-50 lessons** organized into progressive difficulty levels. **Phase 1 focuses heavily on verbs** - the backbone of language - while introducing topical vocabulary through verb usage contexts.
+A complete curriculum typically consists of **30-50 lessons** organized into progressive difficulty levels. The example below shows a language learning curriculum where **Phase 1 focuses heavily on verbs** - the backbone of language - while introducing topical vocabulary through verb usage contexts.
 
-## Learning Philosophy: Verbs First
+## Learning Philosophy: Verbs First (Language Example)
 
 **Why verbs first?**
 - Verbs are the most frequently used words in any language
@@ -14,7 +14,7 @@ A complete language learning curriculum typically consists of **30-50 lessons** 
 - Conjugation patterns are foundational
 - Topics (weather, food, animals) serve as **vocabulary contexts** for verb learning
 
-**Phase 1 Goal**: Cover the **50 most common verbs** with complete conjugation examples, simultaneously building vocabulary across multiple topics.
+**Language Learning Phase 1 Goal**: Cover the **50 most common verbs** with complete conjugation examples, simultaneously building vocabulary across multiple topics.
 
 ## Suggested Learning Progression
 

--- a/docs/lesson-schema.md
+++ b/docs/lesson-schema.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document describes the structure of individual lesson YAML files used for language learning content. The schema is designed to be flexible and support learning any language pair or educational content.
+This document describes the structure of individual lesson YAML files used for learning content. The schema is designed to be flexible and support learning any topic — languages, math, theory exams, and more.
 
 > **Note**: This document covers individual lesson files only. For information about the index files that organize lessons (`languages.yaml`, `topics.yaml`, `lessons.yaml`), see [YAML Schemas Documentation](yaml-schemas.md).
 

--- a/docs/yaml-schemas.md
+++ b/docs/yaml-schemas.md
@@ -1,6 +1,6 @@
 # YAML Schema Documentation
 
-This document describes the YAML file schemas used for organizing and structuring learning content in the language learning application.
+This document describes the YAML file schemas used for organizing and structuring learning content in the Open Learn platform.
 
 ## Overview
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Language Learning</title>
+    <title>Open Learn</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 </head>
 <body class="bg-gradient-to-br from-primary-500 to-secondary-500 min-h-screen md:p-5">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "language-learning",
+  "name": "open-learn",
   "version": "1.0.0",
-  "description": "Language learning application",
+  "description": "Open Learn - A general-purpose learning platform",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/public/lessons/README.md
+++ b/public/lessons/README.md
@@ -1,25 +1,33 @@
-# Language Lessons
+# Lessons
 
-This directory contains language learning lessons in YAML format. Lessons are organized in a two-level hierarchy based on the learning and teaching languages.
+This directory contains learning content in YAML format for the Open Learn platform. Lessons are organized in a two-level hierarchy based on interface language and topic.
 
 ## Directory Structure
 
 ```
 lessons/
 ├── README.md
+├── languages.yaml              # Root index
 ├── deutsch/                    # Learning in German
+│   ├── topics.yaml
 │   ├── portugiesisch/         # Teaching Portuguese
-│   │   ├── 01-basic-verbs.yaml
-│   │   ├── 02-modal-verbs.yaml
-│   │   └── 03-daily-activities.yaml
+│   │   ├── lessons.yaml
+│   │   ├── 01-essential-verbs/
+│   │   │   ├── content.yaml
+│   │   │   └── audio/
+│   │   └── ...
 │   └── englisch/              # Teaching English
-│       └── 01-greetings.yaml
-├── english/                    # Learning in English (examples)
-│   ├── portugese/             # Teaching Portuguese
-│   ├── math-algebra/          # Non-language topics
-│   └── driver-license/
-└── [learning-language]/
-    └── [teaching-language-or-topic]/
+│       ├── lessons.yaml
+│       └── 01-greetings/
+│           ├── content.yaml
+│           └── audio/
+├── english/                    # Learning in English
+│   ├── topics.yaml
+│   └── german/
+│       ├── lessons.yaml
+│       └── ...
+└── [interface-language]/
+    └── [topic]/
 ```
 
 ## Folder Structure
@@ -28,15 +36,16 @@ Lessons use a **two-level folder hierarchy**:
 
 1. **First level** (`learning`): The language you're learning **in** (interface language)
    - Examples: `deutsch`, `english`, `spanish`
-   
-2. **Second level** (`teaching`): The language or topic being **taught**
-   - Examples: `portugiesisch`, `englisch`, `math-algebra`, `driver-license`
+
+2. **Second level** (`teaching`): The topic being **taught**
+   - Language topics: `portugiesisch`, `englisch`, `german`
+   - Other topics: `math-algebra`, `driver-license`
 
 ### Examples:
 
 - `lessons/deutsch/portugiesisch/` - Learn Portuguese with German explanations
 - `lessons/deutsch/englisch/` - Learn English with German explanations
-- `lessons/english/portugese/` - Learn Portuguese with English explanations
+- `lessons/english/german/` - Learn German with English explanations
 - `lessons/english/math-algebra/` - Learn math/algebra in English
 - `lessons/english/driver-license/` - Driver's license materials in English
 
@@ -45,28 +54,22 @@ This structure allows the same content to be presented from different linguistic
 ## Currently Available:
 
 - **deutsch/portugiesisch/** - Portuguese lessons with German interface
-  - 3 lessons: basic verbs, modal verbs, daily activities
-  
+  - 10 lessons covering essential verbs through advanced concepts
+
 - **deutsch/englisch/** - English lessons with German interface
+  - 1 lesson: greetings and introductions
+
+- **english/german/** - German lessons with English interface
   - 1 lesson: greetings and introductions
 
 ## Adding New Lessons
 
-To add lessons for a new language pair or topic:
+To add lessons for a new topic:
 
 1. Create the folder structure: `lessons/<learning>/<teaching>/`
-2. Add lesson files following the schema (see `docs/lesson-schema.md`)
-3. Number lessons sequentially: `01-topic.yaml`, `02-topic.yaml`, etc.
-
-Example for Spanish lessons in an English interface:
-```yaml
-number: 1
-title: "Basic Greetings"
-description: "Learn common Spanish greetings"
-sections: [...]
-```
-
-**Note**: Language specification is determined by the folder path, not by fields in the YAML file.
+2. Create `lessons.yaml` listing the lesson folders
+3. Add lesson folders with `content.yaml` following the schema (see `docs/lesson-schema.md`)
+4. Optionally add `audio/` subfolders with MP3 files
 
 ## Lesson File Format
 
@@ -79,69 +82,13 @@ All lessons follow the YAML schema documented in `/docs/lesson-schema.md`. Key e
   - **title**: Section title
   - **explanation**: Optional markdown explanation
   - **examples**: Array of Q&A examples
-    - **q**: Question/source sentence
-    - **a**: Answer/translation
-    - **labels**: Optional array of labels (e.g., ["Futur", "Gerundium"])
-    - **rel**: Related items (vocabulary)
-
-### Example Labels
-
-Labels help categorize examples by grammar concepts:
-- **Futur** - Future tense
-- **Gerundium** - Gerund forms
-- **Passiv** - Passive voice
-- **Präteritum** - Past tense
-- **Konjunktiv** - Subjunctive mood
-
-Labels are displayed on example cards and can be used to filter or search for specific grammar topics.
-
-## Loading Lessons
-
-To load lessons in your application:
-
-```javascript
-// Example: Load all Portuguese lessons (German interface)
-const portugueseLessons = [
-  'lessons/deutsch/portugiesisch/01-basic-verbs.yaml',
-  'lessons/deutsch/portugiesisch/02-modal-verbs.yaml',
-  'lessons/deutsch/portugiesisch/03-daily-activities.yaml'
-];
-
-// Example: Load English lessons (German interface)
-const englishLessons = [
-  'lessons/deutsch/englisch/01-greetings.yaml'
-];
-
-// Use a YAML parser to load the files
-// For example with js-yaml:
-// const lesson = YAML.parse(fs.readFileSync(lessonPath, 'utf8'));
-```
-
-## Folder Naming Conventions
-
-Use lowercase folder names without special characters:
-- **German**: `deutsch`
-- **English**: `englisch`, `english`
-- **Portuguese**: `portugiesisch`, `portugese`
-- **Spanish**: `spanisch`, `spanish`
-- **Topics**: `math-algebra`, `driver-license`, etc.
-
-## Contributing
-
-When adding new lessons:
-
-1. Follow the schema documentation
-2. Create appropriate folder structure: `lessons/<learning>/<teaching>/`
-3. Maintain consistent numbering within each folder
-4. Include 5-10 sections per lesson
-5. Provide 3-5 examples per section
-6. Add relevant vocabulary in the `rel` field
-7. Use markdown for explanations when needed
-8. Add labels to examples for grammar categorization
+    - **q**: Question/source content
+    - **a**: Answer/target content
+    - **labels**: Optional array of labels
+    - **rel**: Related items (vocabulary, concepts)
 
 ## See Also
 
 - `/docs/lesson-schema.md` - Complete schema documentation with examples
-- `/docs/quick-start.md` - Quick start guide
-- `/docs/usage-examples.md` - Code examples
-- Example lessons in `deutsch/portugiesisch/` and `deutsch/englisch/`
+- `/docs/yaml-schemas.md` - Index file schemas (languages, topics, lessons)
+- `/docs/audio-system.md` - Audio generation and playback

--- a/public/lessons/deutsch/portugiesisch-remote/README.md
+++ b/public/lessons/deutsch/portugiesisch-remote/README.md
@@ -16,8 +16,8 @@ This topic folder contains only a `lessons.yaml` file that references lessons vi
 
 All URLs point to the Portuguese lessons on GitHub Pages:
 ```
-https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/01-essential-verbs
-https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/02-action-verbs
+https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/01-essential-verbs
+https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/02-action-verbs
 ...
 ```
 

--- a/public/lessons/deutsch/portugiesisch-remote/lessons.yaml
+++ b/public/lessons/deutsch/portugiesisch-remote/lessons.yaml
@@ -3,13 +3,13 @@
 # This demonstrates how lessons can be loaded from remote sources
 lessons:
   # All lessons loaded via URL (pointing to GitHub Pages)
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/01-essential-verbs
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/02-action-verbs
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/03-modal-communication
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/04-perception-knowledge
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/05-desire-preference
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/06-carrying-meeting
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/07-thinking-speaking
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/08-looking-asking
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/09-arriving-obligation
-  - url: https://felixboehm.github.io/language/lessons/deutsch/portugiesisch/10-following-beginning
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/01-essential-verbs
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/02-action-verbs
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/03-modal-communication
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/04-perception-knowledge
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/05-desire-preference
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/06-carrying-meeting
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/07-thinking-speaking
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/08-looking-asking
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/09-arriving-obligation
+  - url: https://felixboehm.github.io/open-learn/lessons/deutsch/portugiesisch/10-following-beginning

--- a/src/App.vue
+++ b/src/App.vue
@@ -90,7 +90,7 @@ import { useSettings } from './composables/useSettings'
 const router = useRouter()
 const route = useRoute()
 
-const pageTitle = ref('🌍 Language Learning')
+const pageTitle = ref('🎓 Open Learn')
 
 const { isPlaying, play, pause, resume } = useAudio()
 const { settings } = useSettings()

--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -178,7 +178,7 @@ function setupMediaSession(lessonTitle, learning, teaching) {
   navigator.mediaSession.metadata = new MediaMetadata({
     title: lessonTitle,
     artist: `Learning ${teaching}`,
-    album: `Language Learning - ${learning}`,
+    album: `Open Learn - ${learning}`,
     artwork: [
       { src: artworkUrl, sizes: '512x512', type: 'image/svg+xml' }
     ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,7 +10,7 @@ const routes = [
     path: '/',
     name: 'home',
     component: Home,
-    meta: { title: '🌍 Language Learning' }
+    meta: { title: '🎓 Open Learn' }
   },
   {
     path: '/:learning/:teaching/lessons',

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Language Learning App', () => {
+test.describe('Open Learn App', () => {
   test('should load the homepage without errors', async ({ page }) => {
     // Listen for console errors
     const errors = [];
@@ -21,7 +21,7 @@ test.describe('Language Learning App', () => {
     }
     
     // Check that the page title is set
-    await expect(page).toHaveTitle('Language Learning');
+    await expect(page).toHaveTitle('Open Learn');
     
     // Check that the app div exists
     const app = page.locator('#app');

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig(({ command }) => ({
     // Only use SSL in dev mode, not for preview/build
     ...(command === 'serve' && !process.env.CI ? [basicSsl()] : [])
   ],
-  base: '/language/',
+  base: '/open-learn/',
   server: {
     https: command === 'serve' && !process.env.CI,
     cors: true  // Enable CORS for cross-origin requests


### PR DESCRIPTION
## Summary

- Rebrand the project from "Language Learning" to **Open Learn** — a general-purpose learning platform for any topic (languages, math, theory exams, etc.)
- Update all UI titles, config (`vite.config.js` base path, `package.json`), tests, and documentation
- Update remote lesson URLs from `/language/` to `/open-learn/`

## Changed files (16)

**Code & Config**: `package.json`, `vite.config.js`, `index.html`, `src/App.vue`, `src/router/index.js`, `src/composables/useAudio.js`
**Tests**: `tests/e2e/app.spec.js`
**Documentation**: `README.md`, `CLAUDE.md`, `docs/audio-system.md`, `docs/yaml-schemas.md`, `docs/lesson-schema.md`, `docs/lesson-plan-template.md`, `public/lessons/README.md`
**Content**: `public/lessons/deutsch/portugiesisch-remote/lessons.yaml`, `public/lessons/deutsch/portugiesisch-remote/README.md`

## Test plan

- [x] `pnpm build` succeeds
- [x] Unit tests pass (9/9)
- [ ] `pnpm dev` — verify app shows "Open Learn" title
- [ ] E2E tests pass with updated title assertion