### PR TITLE
fix: use clean slugs instead of encoded URLs for remote topic routes

### DIFF
--- a/src/composables/useAudio.js
+++ b/src/composables/useAudio.js
@@ -3,7 +3,7 @@ import { useLessons } from './useLessons'
 import { useProgress } from './useProgress'
 
 // Get lesson composable for language codes
-const { getLanguageCode, getTopicCode } = useLessons()
+const { getLanguageCode, getTopicCode, resolveTopicKey } = useLessons()
 
 // Get progress composable for learned items
 const { areAllItemsLearned } = useProgress()
@@ -29,14 +29,17 @@ function buildReadingQueue(lesson, learning, teaching, settings) {
   const baseUrl = import.meta.env.BASE_URL
   const lessonFilename = lesson._filename || `${String(lesson.number).padStart(2, '0')}-lesson`
 
+  // Resolve slug to URL if needed (e.g. "workshop-open-learn~topic" → full URL)
+  const resolvedTeaching = resolveTopicKey(teaching)
+
   // Determine audio base path based on lesson source
   let audioBase
   if (lesson._source && lesson._source.type === 'url') {
     // Lesson is from URL
     audioBase = `${lesson._source.path}/audio`
-  } else if (teaching && (teaching.startsWith('http://') || teaching.startsWith('https://'))) {
-    // Topic is from URL
-    audioBase = `${teaching}/${lessonFilename}/audio`
+  } else if (resolvedTeaching && (resolvedTeaching.startsWith('http://') || resolvedTeaching.startsWith('https://'))) {
+    // Topic is from URL (resolved from slug)
+    audioBase = `${resolvedTeaching}/${lessonFilename}/audio`
   } else if (learning && (learning.startsWith('http://') || learning.startsWith('https://'))) {
     // Language is from URL
     audioBase = `${learning}/${teaching}/${lessonFilename}/audio`

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -15,11 +15,10 @@ export function formatLangName(lang) {
 
   if (names[lang]) return names[lang]
 
-  // For URL-based topics, extract the last path segment
-  if (lang.startsWith('http://') || lang.startsWith('https://')) {
-    const parts = lang.replace(/\/+$/, '').split('/')
-    const lastPart = parts[parts.length - 1]
-    return lastPart.charAt(0).toUpperCase() + lastPart.slice(1).replace(/-/g, ' ')
+  // For slug-based remote topics (e.g. "workshop-open-learn~open-learn-workshop")
+  if (lang.includes('~')) {
+    const topicPart = lang.split('~').pop()
+    return topicPart.charAt(0).toUpperCase() + topicPart.slice(1).replace(/-/g, ' ')
   }
 
   return lang.charAt(0).toUpperCase() + lang.slice(1)

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -95,7 +95,7 @@ import { useLessons } from '../composables/useLessons'
 import { formatLangName } from '../utils/formatters'
 
 const router = useRouter()
-const { availableContent, isLoading, loadAvailableContent, loadTopicsForLanguage, removeContentSource, isRemoteTopic } = useLessons()
+const { availableContent, isLoading, loadAvailableContent, loadTopicsForLanguage, removeContentSource, isRemoteTopic, getSourceForSlug } = useLessons()
 
 const selectedLearning = ref(null)
 const selectedTeaching = ref(null)
@@ -128,19 +128,13 @@ function selectTeaching(topic) {
   localStorage.setItem('lastTeachingTopic', topic)
 }
 
-async function removeSource(topicUrl) {
-  // Find the content source base URL from the topic URL
-  // Topic URLs look like: https://user.github.io/repo/lang/topic
-  // We need to find which content source it belongs to
-  const sources = JSON.parse(localStorage.getItem('contentSources') || '[]')
-  for (const source of sources) {
-    if (topicUrl.startsWith(source)) {
-      removeContentSource(source)
-      break
-    }
+async function removeSource(topicSlug) {
+  const sourceUrl = getSourceForSlug(topicSlug)
+  if (sourceUrl) {
+    removeContentSource(sourceUrl)
   }
   // Clear selection if removed topic was selected
-  if (selectedTeaching.value === topicUrl) {
+  if (selectedTeaching.value === topicSlug) {
     selectedTeaching.value = null
     localStorage.removeItem('lastTeachingTopic')
   }
@@ -156,8 +150,8 @@ function loadLessons() {
     router.push({
       name: 'lessons-overview',
       params: {
-        learning: encodeURIComponent(selectedLearning.value),
-        teaching: encodeURIComponent(selectedTeaching.value)
+        learning: selectedLearning.value,
+        teaching: selectedTeaching.value
       }
     })
   }

--- a/src/views/LearningItems.vue
+++ b/src/views/LearningItems.vue
@@ -182,9 +182,8 @@ const emit = defineEmits(['update-title'])
 const { loadAllLessonsForTopic } = useLessons()
 const { isItemLearned, toggleItemLearned } = useProgress()
 
-// Use computed to make params reactive to route changes (URL-decoded for remote sources)
-const learning = computed(() => decodeURIComponent(route.params.learning))
-const teaching = computed(() => decodeURIComponent(route.params.teaching))
+const learning = computed(() => route.params.learning)
+const teaching = computed(() => route.params.teaching)
 const lessonNumber = computed(() => route.params.number ? parseInt(route.params.number) : null)
 
 const allItems = ref([])
@@ -322,12 +321,12 @@ watch(selectedLesson, (newValue) => {
   if (newValue === 'all') {
     router.replace({
       name: 'learning-items',
-      params: { learning: encodeURIComponent(learning.value), teaching: encodeURIComponent(teaching.value) }
+      params: { learning: learning.value, teaching: teaching.value }
     })
   } else {
     router.replace({
       name: 'learning-items',
-      params: { learning: encodeURIComponent(learning.value), teaching: encodeURIComponent(teaching.value), number: newValue }
+      params: { learning: learning.value, teaching: teaching.value, number: newValue }
     })
   }
 })

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -135,9 +135,8 @@ const { isPlaying, isPaused, currentItem, initializeAudio, jumpToExample, cleanu
 
 const lesson = ref(null)
 
-// Use computed to get current route params (URL-decoded for remote sources)
-const learning = computed(() => decodeURIComponent(route.params.learning))
-const teaching = computed(() => decodeURIComponent(route.params.teaching))
+const learning = computed(() => route.params.learning)
+const teaching = computed(() => route.params.teaching)
 const lessonNumber = computed(() => parseInt(route.params.number))
 
 // Filter sections to show only examples that have unlearned items (if setting is enabled)
@@ -249,8 +248,8 @@ watch(
 )
 
 onMounted(async () => {
-  const currentLearning = decodeURIComponent(route.params.learning)
-  const currentTeaching = decodeURIComponent(route.params.teaching)
+  const currentLearning = route.params.learning
+  const currentTeaching = route.params.teaching
   const currentLessonNumber = parseInt(route.params.number)
 
   // Load all lessons to find the correct file

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -53,16 +53,15 @@ const { loadAllLessonsForTopic } = useLessons()
 const lessons = ref([])
 const isLoading = ref(true)
 
-// Use computed to get current route params (URL-decoded for remote sources)
-const learning = computed(() => decodeURIComponent(route.params.learning))
-const teaching = computed(() => decodeURIComponent(route.params.teaching))
+const learning = computed(() => route.params.learning)
+const teaching = computed(() => route.params.teaching)
 
 function openLesson(number) {
   router.push({
     name: 'lesson-detail',
     params: {
-      learning: encodeURIComponent(learning.value),
-      teaching: encodeURIComponent(teaching.value),
+      learning: learning.value,
+      teaching: teaching.value,
       number
     }
   })


### PR DESCRIPTION
## Summary
- Replace double-encoded URL parameters (`https%253A%252F%252F...`) with clean slugs (`workshop-open-learn~open-learn-workshop`) for remote topic routes
- Add `generateSlug()` and bidirectional `topicSlugMap` in useLessons.js for slug↔URL resolution
- Remove all `encodeURIComponent`/`decodeURIComponent` calls from views (LessonsOverview, LessonDetail, LearningItems)
- Update `formatters.js` to display slug-based topic names (extracts part after `~`)
- Update `useAudio.js` to resolve slugs to URLs for correct audio path construction

## Before
`#/deutsch/https%253A%252F%252Ffelixboehm.github.io%252Fworkshop-open-learn%252Fdeutsch%252Fopen-learn-workshop/lessons`

## After
`#/deutsch/workshop-open-learn~open-learn-workshop/lessons`

## Test plan
- [ ] Local topics still load correctly (no slugs, no change)
- [ ] Remote topics use clean slug URLs in the browser
- [ ] Audio playback works for remote topic lessons
- [ ] Remove button (✕) works for remote topics on home page
- [ ] `formatLangName()` displays readable names for slugs