### PR TITLE
feat: topic cards with metadata, share links and workshop discovery

### DIFF
--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -1,5 +1,19 @@
 <template>
   <div>
+    <!-- Source indicator for remote topics -->
+    <div v-if="!isLoading && isRemote" class="mb-4 flex items-center justify-between text-sm">
+      <div>
+        <span v-if="topicDescription" class="text-gray-600 dark:text-gray-400">{{ topicDescription }}</span>
+        <span v-if="topicDescription && sourceLabel" class="text-gray-300 dark:text-gray-600 mx-2">·</span>
+        <span v-if="sourceLabel" class="text-gray-400 dark:text-gray-500">{{ sourceLabel }}</span>
+      </div>
+      <button
+        @click="copyShareLink"
+        class="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-500 hover:text-primary-500 hover:border-primary-500 transition text-xs">
+        {{ copied ? 'Copied!' : 'Share' }}
+      </button>
+    </div>
+
     <!-- Lessons grid -->
     <div v-if="!isLoading && lessons.length > 0" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
       <div
@@ -48,13 +62,35 @@ const router = useRouter()
 const route = useRoute()
 const emit = defineEmits(['update-title'])
 
-const { loadAllLessonsForTopic } = useLessons()
+const { loadAllLessonsForTopic, isRemoteTopic, getSourceForSlug, getTopicMeta, getShareUrl } = useLessons()
 
 const lessons = ref([])
 const isLoading = ref(true)
+const copied = ref(false)
 
 const learning = computed(() => route.params.learning)
 const teaching = computed(() => route.params.teaching)
+
+const isRemote = computed(() => isRemoteTopic(teaching.value))
+const topicDescription = computed(() => {
+  const meta = getTopicMeta(learning.value, teaching.value)
+  return meta.description || null
+})
+const sourceLabel = computed(() => {
+  const url = getSourceForSlug(teaching.value)
+  if (!url) return ''
+  try { return new URL(url).hostname } catch { return '' }
+})
+
+async function copyShareLink() {
+  const url = getShareUrl(teaching.value)
+  if (!url) return
+  try {
+    await navigator.clipboard.writeText(url)
+    copied.value = true
+    setTimeout(() => { copied.value = false }, 2000)
+  } catch {}
+}
 
 function openLesson(number) {
   router.push({
@@ -74,8 +110,9 @@ async function loadLessons() {
   lessons.value = await loadAllLessonsForTopic(learning.value, teaching.value)
   isLoading.value = false
 
-  // Update page title
-  emit('update-title', 'Lessons')
+  // Update page title with topic name
+  const meta = getTopicMeta(learning.value, teaching.value)
+  emit('update-title', meta.title || formatLangName(teaching.value))
 }
 
 // Watch for route changes and reload lessons


### PR DESCRIPTION
## Summary
- Redesign topic selection from plain buttons to cards showing title, description, and source hostname
- Add share link copy button for remote topics (Home page + LessonsOverview)
- Add "Discover Workshops" section on Home page linking to the Open Learn Workshop
- Extend `topics.yaml` schema with optional `title` and `description` fields (backward compatible)
- Show topic title from metadata in LessonsOverview page header

## Details
- `useLessons.js`: New `topicMeta` ref, `getTopicMeta()`, `getShareUrl()`, extended `parseSource()`
- `Home.vue`: Topic cards, clipboard share, workshop discovery section
- `LessonsOverview.vue`: Source indicator bar with description, hostname, and share button

## Test plan
- [ ] Local topics display as cards with formatted name (no title/description fallback)
- [ ] Remote topics show title, description, source hostname from metadata
- [ ] Share link copies correct URL to clipboard with visual feedback
- [ ] Workshop discovery section shows available workshops, hides after adding
- [ ] LessonsOverview shows source info and share button for remote topics
- [ ] LessonsOverview title shows topic metadata title