### PR TITLE
docs: update all languages.yaml references to index.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ open-learn/
 │       └── formatters.js  # Display name formatting
 ├── public/
 │   └── lessons/           # YAML lesson content (deployed as-is)
-│       ├── languages.yaml # Root index - lists available interface languages
+│       ├── index.yaml    # Root index - lists available interface languages
 │       ├── deutsch/       # German interface folder
 │       │   ├── topics.yaml            # Lists topics (portugiesisch)
 │       │   └── portugiesisch/
@@ -160,7 +160,7 @@ Uses hash-based routing (`createWebHashHistory`) for GitHub Pages compatibility.
 - **Settings Button**: Always visible in top-right corner
 
 **YAML Loading Flow**:
-1. Load `lessons/languages.yaml` → get available interface languages
+1. Load `lessons/index.yaml` → get available interface languages
 2. User selects language → load `lessons/{language}/topics.yaml` → get topics
 3. User selects topic → navigate to `/:learning/:teaching/lessons`
 4. Load `lessons/{language}/{topic}/lessons.yaml` → get lesson folder names
@@ -266,7 +266,7 @@ See `docs/lesson-schema.md` for individual lesson documentation and `docs/yaml-s
 
 ### Adding a New Interface Language
 
-1. Add language to `public/lessons/languages.yaml`:
+1. Add language to `public/lessons/index.yaml`:
    ```yaml
    languages:
      - folder: deutsch

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ open-learn/
 │       └── formatters.js    # Display name formatting
 ├── public/
 │   └── lessons/             # YAML lesson content
-│       ├── languages.yaml   # Root index
+│       ├── index.yaml       # Root index
 │       └── deutsch/         # German learning content
 ├── tests/                   # Test files
 ├── docs/                    # Documentation
@@ -192,7 +192,7 @@ Push to the `main` branch triggers automatic deployment via GitHub Actions (`.gi
 - `#/settings` - Settings panel
 
 ### Data Flow
-1. Load `lessons/languages.yaml` → get available interface languages
+1. Load `lessons/index.yaml` → get available interface languages
 2. Load `lessons/{lang}/topics.yaml` → get topics
 3. Load `lessons/{lang}/{topic}/lessons.yaml` → get lesson folders
 4. Load lesson content dynamically with js-yaml
@@ -204,8 +204,8 @@ Add community workshops to Open Learn by clicking the links below:
 
 | Workshop | Description | Link |
 |----------|-------------|------|
-| **Learn English** | 10 lessons covering 30 core English verbs (German interface) | [Add workshop](https://felixboehm.github.io/open-learn/#/add?source=https://felixboehm.github.io/workshop-english) |
-| **Getting to Know Open Learn** | Learn how the platform works and create your own workshops (DE/EN) | [Add workshop](https://felixboehm.github.io/open-learn/#/add?source=https://felixboehm.github.io/workshop-open-learn) |
+| **Learn English** | 10 lessons covering 30 core English verbs (German interface) | [Add workshop](https://felixboehm.github.io/open-learn/#/add?source=https://felixboehm.github.io/workshop-english/index.yaml) |
+| **Getting to Know Open Learn** | Learn how the platform works and create your own workshops (DE/EN) | [Add workshop](https://felixboehm.github.io/open-learn/#/add?source=https://felixboehm.github.io/workshop-open-learn/index.yaml) |
 
 Want to create your own workshop? See the [External Workshop Guide](docs/external-workshop-guide.md).
 

--- a/generate-audio.sh
+++ b/generate-audio.sh
@@ -14,7 +14,7 @@
 #   ./generate-audio.sh -f path/to/lesson-folder/ # Force single lesson
 #
 # Works with external workshops too — auto-detects the content root
-# by walking up to find languages.yaml:
+# by walking up to find index.yaml:
 #   ./generate-audio.sh /path/to/workshop/deutsch/topic/01-lesson/
 
 LESSONS_DIR="public/lessons"
@@ -101,9 +101,9 @@ get_voice() {
     code=$(get_language_code "$parent_dir/index.yaml" "$folder_name")
   fi
 
-  # Try main languages.yaml
+  # Try main index.yaml
   if [[ -z "$code" || "$code" == "null" ]]; then
-    code=$(get_language_code "$content_root/languages.yaml" "$folder_name")
+    code=$(get_language_code "$content_root/index.yaml" "$folder_name")
   fi
 
   # Look up voice by code
@@ -126,11 +126,11 @@ get_voice() {
   echo "Alex"
 }
 
-# Function to find the content root by walking up to find languages.yaml
+# Function to find the content root by walking up to find index.yaml
 find_content_root() {
   local dir="$1"
   while [[ "$dir" != "/" ]]; do
-    if [[ -f "$dir/languages.yaml" ]]; then
+    if [[ -f "$dir/index.yaml" ]]; then
       echo "$dir"
       return
     fi


### PR DESCRIPTION
## Summary
- Update remaining `languages.yaml` references to `index.yaml` in CLAUDE.md, README.md, and generate-audio.sh
- Add `/index.yaml` suffix to workshop share links in README

## Test plan
- [ ] Verify `generate-audio.sh` still finds content root for external workshops
- [ ] Verify no remaining `languages.yaml` references: `grep -r languages.yaml .`