### PR TITLE
fix: correct base URL derivation in AddSource view

### DIFF
--- a/src/views/AddSource.vue
+++ b/src/views/AddSource.vue
@@ -164,7 +164,7 @@ async function validateSource() {
     }
 
     // Derive base URL by stripping the index.yaml filename
-    const baseUrl = url.replace(/\/workshop\.yaml$/, '')
+    const baseUrl = url.replace(/\/[^/]+\.yaml$/, '')
 
     // Discover content structure
     const content = {}


### PR DESCRIPTION
## Summary
- Fix regex in AddSource.vue that strips the YAML filename from source URL
- Was hardcoded to `workshop.yaml`, now strips any `*.yaml` filename

## Test plan
- [ ] Add workshop via `#/add?source=https://felixboehm.github.io/workshop-open-learn/index.yaml`
- [ ] Verify topics are discovered and displayed