### PR TITLE
feat: add optional video support to sections

### DIFF
--- a/docs/lesson-schema.md
+++ b/docs/lesson-schema.md
@@ -88,11 +88,17 @@ Each lesson contains 5-10 sections. Sections have:
 ```yaml
 sections:
   - title: "Section Title"          # Section title (string)
+    video: "https://youtube.com/watch?v=abc123"  # Optional video URL
     explanation: |                  # Optional markdown explanation
       This is an **explanation** of the section.
       It supports _markdown_ formatting.
     examples: [...]                 # Array of examples (see below)
 ```
+
+**Video Field** (optional):
+- Displayed above the explanation as an embedded video
+- YouTube watch URLs (`youtube.com/watch?v=...`) and short URLs (`youtu.be/...`) are automatically converted to embed URLs
+- Other URLs (e.g., Vimeo embed URLs) are used as-is in an iframe
 
 ### Example Structure
 

--- a/src/views/LessonDetail.vue
+++ b/src/views/LessonDetail.vue
@@ -18,6 +18,17 @@
           {{ section.title }}
         </div>
 
+        <!-- Video -->
+        <div v-if="section.video" class="mb-4">
+          <iframe
+            :src="normalizeVideoUrl(section.video)"
+            class="w-full aspect-video rounded"
+            frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen>
+          </iframe>
+        </div>
+
         <!-- Explanation -->
         <div
           v-if="section.explanation"
@@ -134,6 +145,13 @@ const { isItemLearned, toggleItemLearned, areAllItemsLearned, progress } = usePr
 const { isPlaying, isPaused, currentItem, initializeAudio, jumpToExample, cleanup, play, pause } = useAudio()
 
 const lesson = ref(null)
+
+// Convert YouTube watch/short URLs to embed URLs
+function normalizeVideoUrl(url) {
+  const match = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&?]+)/)
+  if (match) return `https://www.youtube.com/embed/${match[1]}`
+  return url
+}
 
 const learning = computed(() => route.params.learning)
 const teaching = computed(() => route.params.teaching)


### PR DESCRIPTION
## Summary
- Sections can now include an optional `video` field with a URL rendered as an embedded iframe above the explanation
- YouTube watch URLs (`youtube.com/watch?v=...`) and short URLs (`youtu.be/...`) are automatically converted to embed format
- Other video URLs (e.g. Vimeo embed) are passed through as-is

## YAML Example
```yaml
sections:
  - title: "Introduction"
    video: "https://youtube.com/watch?v=abc123"
    explanation: "Markdown text..."
    examples: [...]
```

## Test plan
- [ ] Verify existing lessons without `video` field render unchanged
- [ ] Add a `video` field to a section and verify the iframe renders above the explanation
- [ ] Test YouTube watch URL auto-conversion to embed URL
- [ ] Test YouTube short URL (youtu.be) auto-conversion
- [ ] Test non-YouTube URL passthrough (e.g. Vimeo embed URL)
- [ ] Run `pnpm test` — all 9 tests pass