### PR TITLE
feat: add coach answer forwarding with consent

### DIFF
--- a/docs/lesson-schema.md
+++ b/docs/lesson-schema.md
@@ -67,19 +67,53 @@ See [yaml-schemas.md](yaml-schemas.md) for detailed documentation on the index f
 ### Top Level
 
 ```yaml
-version: 1                          # Lesson format version (integer, optional)
+version: 2                          # Lesson format version (integer, optional)
 number: 1                           # Lesson number (integer)
 title: "Lesson Title"               # Lesson title (string)
 description: "Brief description"    # Optional lesson description
+coach:                              # Optional: coach API for answer forwarding
+  api: "https://coach.example.com/api/answers"
+  name: "Coach Name"                # Optional: displayed in UI
 sections: [...]                     # Array of sections (see below)
 ```
 
 **Version Field**:
 - **version** (integer, optional): Lesson format version number
-- Current version: `1`
+- Current version: `2`
 - Used to track lesson format changes and ensure compatibility
-- Future versions may add or change fields
+- Version 1 content is fully backward compatible
 - If omitted, assumed to be version 1
+
+### Coach Configuration (Optional)
+
+The `coach` field enables answer forwarding to a workshop coach's server:
+
+- **api** (string, required): HTTP endpoint that receives POST requests with answer data
+- **name** (string, optional): Coach or workshop name displayed in the UI
+
+The user must opt-in via Settings > Workshop > "Share Answers with Coach" before any data is sent. Users can optionally provide an email/username for identification.
+
+**API Contract — `POST {coach.api}`:**
+
+```json
+{
+  "lesson": {
+    "learning": "deutsch",
+    "teaching": "portugiesisch",
+    "number": 1,
+    "title": "Lesson Title"
+  },
+  "section": { "index": 0, "title": "Section Title" },
+  "example": { "index": 0, "type": "input", "question": "Translate: ..." },
+  "answer": { "value": "user's answer", "correct": true },
+  "user": "user@example.com",
+  "timestamp": "2026-02-19T10:30:00.000Z"
+}
+```
+
+- `user` is only included if the user provided an identifier in settings
+- `answer.correct` is `null` if no correct answer is defined
+- Coach can return `401` to reject unauthorized users; optionally include `{ "enrollUrl": "https://..." }` in the response body
 
 ### Section Structure
 

--- a/src/composables/useSettings.js
+++ b/src/composables/useSettings.js
@@ -9,7 +9,9 @@ const settings = ref({
   audioSpeed: 1.0, // Audio playback speed: 0.6, 0.8, 1.0
   readAnswers: true, // Whether to read the answer/translation during auto-play
   hideLearnedExamples: true, // Whether to hide examples where all items are learned
-  showDebugOverlay: false // Show debug overlay for audio playback
+  showDebugOverlay: false, // Show debug overlay for audio playback
+  coachConsent: false, // Global consent to forward answers to coach APIs
+  coachIdentifier: '' // Optional email/username for coach identification
 })
 
 let isInitialized = false
@@ -82,6 +84,14 @@ function initializeWatchers() {
   })
 
   watch(() => settings.value.showDebugOverlay, () => {
+    saveSettings()
+  })
+
+  watch(() => settings.value.coachConsent, () => {
+    saveSettings()
+  })
+
+  watch(() => settings.value.coachIdentifier, () => {
     saveSettings()
   })
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -177,6 +177,48 @@
       </label>
     </div>
     </div>
+
+    <!-- Workshop Section -->
+    <div class="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg">
+      <h2 class="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-6 pb-3 border-b-2 border-gray-300 dark:border-gray-600">
+        Workshop
+      </h2>
+
+      <!-- Coach Consent Toggle -->
+      <div class="mb-6">
+        <label class="block font-semibold text-gray-800 dark:text-gray-200 mb-2 text-lg">
+          Share Answers with Coach
+        </label>
+        <div class="text-gray-600 dark:text-gray-400 text-sm mb-3">
+          Allow sending your assessment answers to the workshop coach's server.
+          This only applies to lessons that have a coach configured.
+        </div>
+        <label class="relative inline-block w-14 h-8 cursor-pointer">
+          <input
+            type="checkbox"
+            v-model="settings.coachConsent"
+            class="opacity-0 w-0 h-0 peer" />
+          <span
+            class="absolute cursor-pointer top-0 left-0 right-0 bottom-0 bg-gray-300 dark:bg-gray-600 transition rounded-full peer-checked:bg-primary-500 before:content-[''] before:absolute before:h-6 before:w-6 before:left-1 before:bottom-1 before:bg-white before:transition before:rounded-full peer-checked:before:translate-x-6">
+          </span>
+        </label>
+      </div>
+
+      <!-- Coach Identifier -->
+      <div v-if="settings.coachConsent" class="mb-6">
+        <label class="block font-semibold text-gray-800 dark:text-gray-200 mb-2 text-lg">
+          Your Name or Email (optional)
+        </label>
+        <div class="text-gray-600 dark:text-gray-400 text-sm mb-3">
+          Identify yourself to the coach. Leave empty for anonymous submissions.
+        </div>
+        <input
+          type="text"
+          v-model="settings.coachIdentifier"
+          class="w-full p-2 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200"
+          placeholder="your@email.com or username" />
+      </div>
+    </div>
   </div>
 </template>
 

--- a/tests/coach-forwarding.test.js
+++ b/tests/coach-forwarding.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useAssessments } from '../src/composables/useAssessments'
+
+describe('Coach Answer Forwarding', () => {
+  let assessments
+
+  beforeEach(() => {
+    localStorage.clear()
+    assessments = useAssessments()
+    assessments.assessments.value = {}
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not forward when consent is disabled', async () => {
+    const result = await assessments.forwardToCoach(
+      { api: 'https://coach.example.com/api' },
+      { answer: { value: 'test' } },
+      { coachConsent: false, coachIdentifier: '' }
+    )
+    expect(result).toBeNull()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not forward when no coach API is configured', async () => {
+    const result = await assessments.forwardToCoach(
+      null,
+      { answer: { value: 'test' } },
+      { coachConsent: true, coachIdentifier: '' }
+    )
+    expect(result).toBeNull()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not forward when coach config has no api', async () => {
+    const result = await assessments.forwardToCoach(
+      { name: 'Coach' },
+      { answer: { value: 'test' } },
+      { coachConsent: true, coachIdentifier: '' }
+    )
+    expect(result).toBeNull()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('forwards answer when consent is enabled', async () => {
+    fetch.mockResolvedValue({ ok: true })
+
+    const result = await assessments.forwardToCoach(
+      { api: 'https://coach.example.com/api' },
+      { lesson: { number: 1 }, answer: { value: 'test', correct: true } },
+      { coachConsent: true, coachIdentifier: '' }
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://coach.example.com/api',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' }
+      })
+    )
+  })
+
+  it('includes user identifier when provided', async () => {
+    fetch.mockResolvedValue({ ok: true })
+
+    await assessments.forwardToCoach(
+      { api: 'https://coach.example.com/api' },
+      { answer: { value: 'test' } },
+      { coachConsent: true, coachIdentifier: 'user@test.com' }
+    )
+
+    const body = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(body.user).toBe('user@test.com')
+  })
+
+  it('omits user field when identifier is empty', async () => {
+    fetch.mockResolvedValue({ ok: true })
+
+    await assessments.forwardToCoach(
+      { api: 'https://coach.example.com/api' },
+      { answer: { value: 'test' } },
+      { coachConsent: true, coachIdentifier: '' }
+    )
+
+    const body = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(body.user).toBeUndefined()
+  })
+
+  it('returns enrollUrl on 401 response', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ enrollUrl: 'https://workshop.example.com/enroll' })
+    })
+
+    const result = await assessments.forwardToCoach(
+      { api: 'https://coach.example.com/api' },
+      { answer: { value: 'test' } },
+      { coachConsent: true, coachIdentifier: '' }
+    )
+
+    expect(result).toEqual({ ok: false, enrollUrl: 'https://workshop.example.com/enroll' })
+  })
+
+  it('handles 401 without enrollUrl', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({})
+    })
+
+    const result = await assessments.forwardToCoach(
+      { api: 'https://coach.example.com/api' },
+      { answer: { value: 'test' } },
+      { coachConsent: true, coachIdentifier: '' }
+    )
+
+    expect(result).toEqual({ ok: false, enrollUrl: null })
+  })
+
+  it('returns null on network error', async () => {
+    fetch.mockRejectedValue(new Error('Network error'))
+
+    const result = await assessments.forwardToCoach(
+      { api: 'https://coach.example.com/api' },
+      { answer: { value: 'test' } },
+      { coachConsent: true, coachIdentifier: '' }
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('includes timestamp in payload', async () => {
+    fetch.mockResolvedValue({ ok: true })
+
+    await assessments.forwardToCoach(
+      { api: 'https://coach.example.com/api' },
+      { answer: { value: 'test' } },
+      { coachConsent: true, coachIdentifier: '' }
+    )
+
+    const body = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(body.timestamp).toBeDefined()
+    expect(new Date(body.timestamp).getTime()).not.toBeNaN()
+  })
+})


### PR DESCRIPTION
## Summary
- Workshop creators can configure a `coach.api` endpoint in lesson YAML to receive assessment answers
- Users must opt-in globally via Settings > Workshop > "Share Answers with Coach"
- Optional email/username identifier for non-anonymous submissions
- On 401 responses, shows an enroll hint with optional enrollment link from coach response
- Fire-and-forget: network failures don't block the user experience

**Depends on:** #14 (merge that first, then rebase this PR onto main)

## New settings
- `coachConsent` (boolean) — global opt-in toggle
- `coachIdentifier` (string) — optional email/username

## YAML Example
```yaml
version: 2
coach:
  api: "https://coach.example.com/api/answers"
  name: "Workshop Coach Name"
sections: [...]
```

## API Contract
```json
{
  "lesson": { "learning": "deutsch", "teaching": "portugiesisch", "number": 1, "title": "..." },
  "section": { "index": 0, "title": "Section Title" },
  "example": { "index": 0, "type": "input", "question": "..." },
  "answer": { "value": "user's answer", "correct": true },
  "user": "user@example.com",
  "timestamp": "2026-02-19T10:30:00.000Z"
}
```

## Test plan
- [ ] Verify answers are NOT forwarded when consent is disabled
- [ ] Enable consent, submit an assessment in a lesson with coach config — verify POST is sent
- [ ] Test with email/username — verify `user` field is included in payload
- [ ] Test without identifier — verify anonymous submission (no `user` field)
- [ ] Test 401 response — verify enroll hint is displayed
- [ ] Test 401 with `enrollUrl` in response body — verify link is shown
- [ ] Test network failure — verify no error shown to user, answer still saved locally
- [ ] Run `pnpm test` — all 34 tests pass