### PR TITLE
feat: add showcase workshop with fun facts and feedback

### DIFF
--- a/public/lessons/english/open-learn-showcase/01-amazing-animal-facts/content.yaml
+++ b/public/lessons/english/open-learn-showcase/01-amazing-animal-facts/content.yaml
@@ -1,0 +1,103 @@
+version: 2
+number: 1
+title: "Amazing Animal Facts"
+description: "Mind-blowing things you never knew about the animal kingdom. This lesson showcases Q&A examples, labels, related items, video, and markdown explanations."
+
+sections:
+  - title: "Ocean Creatures"
+    video: "https://www.youtube.com/watch?v=eOjkHiGHSd8"
+    explanation: |
+      The ocean covers **71%** of Earth's surface, and we've explored less than 5% of it.
+      Here are some incredible facts about the creatures living down there.
+
+      > This section demonstrates: video embeds, markdown explanations, Q&A examples, and related items.
+    examples:
+      - q: "How many hearts does an octopus have?"
+        a: "Three — two pump blood to the gills, one pumps it to the rest of the body."
+        labels: ["Anatomy"]
+        rel:
+          - ["octopus", "8 arms, 3 hearts, blue blood"]
+          - ["cephalopod", "class of mollusks including octopus and squid"]
+
+      - q: "What animal can survive being frozen solid?"
+        a: "The wood frog — it can survive with 65% of its body water frozen."
+        labels: ["Survival"]
+        rel:
+          - ["wood frog", "Rana sylvatica, found in North America"]
+          - ["cryoprotectant", "natural antifreeze produced by the frog's liver"]
+
+      - q: "How long can a dolphin stay awake?"
+        a: "Indefinitely — dolphins sleep with one half of their brain at a time."
+        labels: ["Sleep", "Brain"]
+        rel:
+          - ["unihemispheric sleep", "sleeping with one brain hemisphere at a time"]
+          - ["dolphin", "highly intelligent marine mammal"]
+
+      - q: "What color is a lobster's blood?"
+        a: "Clear — but it turns blue when exposed to oxygen (it contains copper, not iron)."
+        labels: ["Anatomy"]
+        rel:
+          - ["hemocyanin", "copper-based oxygen transport protein"]
+          - ["lobster", "crustacean with copper-based blood"]
+
+  - title: "Insects & Tiny Creatures"
+    explanation: |
+      Insects make up about **80%** of all known animal species.
+      Some of their abilities put science fiction to shame.
+    examples:
+      - q: "How far can a flea jump relative to its body size?"
+        a: "A flea can jump 150 times its own body length — like a human jumping over a 75-story building."
+        labels: ["Strength"]
+        rel:
+          - ["flea", "tiny parasitic insect, incredible jumper"]
+          - ["resilin", "elastic protein in flea legs enabling jumps"]
+
+      - q: "How many lenses does a dragonfly's eye have?"
+        a: "About 30,000 — giving it nearly 360-degree vision."
+        labels: ["Vision"]
+        rel:
+          - ["compound eye", "eye made of thousands of individual lenses"]
+          - ["dragonfly", "ancient insect, virtually unchanged for 300 million years"]
+
+      - q: "Can a cockroach live without its head?"
+        a: "Yes, for about a week — it eventually dies of thirst because it can't drink."
+        labels: ["Survival"]
+        rel:
+          - ["cockroach", "one of the most resilient insects on Earth"]
+          - ["open circulatory system", "blood not confined to vessels, allows headless survival"]
+
+      - q: "What is the strongest animal relative to its size?"
+        a: "The dung beetle — it can pull 1,141 times its own body weight."
+        labels: ["Strength"]
+        rel:
+          - ["dung beetle", "rolls balls of dung, incredibly strong"]
+          - ["Onthophagus taurus", "species of horned dung beetle, strongest animal"]
+
+  - title: "Mammals Gone Wild"
+    explanation: |
+      Even the animals we think we know well have some _seriously weird_ hidden talents.
+    examples:
+      - q: "How long does a sloth take to digest a meal?"
+        a: "Up to 30 days — they have the slowest digestion of any mammal."
+        labels: ["Digestion"]
+        rel:
+          - ["sloth", "slowest mammal, sleeps 15-20 hours per day"]
+
+      - q: "What is a group of flamingos called?"
+        a: "A flamboyance."
+        labels: ["Collective nouns"]
+        rel:
+          - ["flamboyance", "collective noun for flamingos"]
+          - ["flamingo", "pink from carotenoid pigments in their diet"]
+
+      - q: "Can cows have best friends?"
+        a: "Yes — studies show cows have best friends and get stressed when separated."
+        labels: ["Behavior"]
+        rel:
+          - ["cow social bonds", "cows form close friendships within herds"]
+
+      - q: "How far away can a wolf howl be heard?"
+        a: "Up to 16 km (10 miles) in open terrain."
+        labels: ["Communication"]
+        rel:
+          - ["wolf howl", "used for long-distance communication and territory marking"]

--- a/public/lessons/english/open-learn-showcase/02-space-food-and-other-nonsense/content.yaml
+++ b/public/lessons/english/open-learn-showcase/02-space-food-and-other-nonsense/content.yaml
@@ -1,0 +1,128 @@
+version: 2
+number: 2
+title: "Space, Food & Other Nonsense"
+description: "Test your useless knowledge with quizzes! This lesson showcases all assessment types: text input, multiple choice, and single select."
+
+sections:
+  - title: "Space Quiz"
+    explanation: |
+      Think you know the universe? Let's find out.
+
+      **How it works:** Type your answer, pick checkboxes, or select a radio button — then hit Submit.
+      Your answers are saved locally so you can come back later.
+    examples:
+      - type: input
+        q: "What planet in our solar system has the most moons?"
+        a:
+          - "Saturn"
+          - "saturn"
+        labels: ["Space"]
+
+      - type: select
+        q: "How long does sunlight take to reach Earth?"
+        options:
+          - text: "About 8 seconds"
+          - text: "About 8 minutes"
+            correct: true
+          - text: "About 8 hours"
+          - text: "About 8 days"
+        labels: ["Space"]
+
+      - type: multiple-choice
+        q: "Which of these are actual names of moons in our solar system?"
+        options:
+          - text: "Titan"
+            correct: true
+          - text: "Nexus"
+          - text: "Europa"
+            correct: true
+          - text: "Ganymede"
+            correct: true
+        labels: ["Space"]
+
+      - q: "One teaspoon of a neutron star weighs about 6 billion tons."
+        a: "That's roughly the weight of Mount Everest — in a teaspoon."
+        labels: ["Space", "Mind-blowing"]
+        rel:
+          - ["neutron star", "collapsed core of a massive star"]
+
+  - title: "Food Trivia"
+    explanation: |
+      Food facts that will make you look at your kitchen differently.
+    examples:
+      - type: input
+        q: "Which fruit floats in water because it is 25% air?"
+        a:
+          - "Apple"
+          - "apple"
+          - "Apples"
+          - "apples"
+        labels: ["Food"]
+
+      - type: select
+        q: "What was the first food eaten in space?"
+        options:
+          - text: "A sandwich"
+          - text: "Applesauce from a tube"
+            correct: true
+          - text: "Freeze-dried ice cream"
+          - text: "A tortilla"
+        labels: ["Food", "Space"]
+
+      - type: multiple-choice
+        q: "Which of these foods are technically berries (botanically)?"
+        options:
+          - text: "Banana"
+            correct: true
+          - text: "Strawberry"
+          - text: "Avocado"
+            correct: true
+          - text: "Watermelon"
+            correct: true
+        labels: ["Food", "Biology"]
+
+      - q: "Honey never spoils. Archaeologists found 3,000-year-old honey in Egyptian tombs — still edible."
+        a: "Its low moisture content and acidic pH create an inhospitable environment for bacteria."
+        labels: ["Food", "History"]
+        rel:
+          - ["honey preservation", "natural antibacterial properties prevent spoilage"]
+
+  - title: "Random Nonsense Round"
+    explanation: |
+      The weirdest facts that don't fit any category. Good luck.
+    examples:
+      - type: input
+        q: "In what country is it illegal to own just one guinea pig (because they get lonely)?"
+        a:
+          - "Switzerland"
+          - "switzerland"
+        labels: ["Laws"]
+
+      - type: select
+        q: "What is the technical term for the fear of long words?"
+        options:
+          - text: "Logophobia"
+          - text: "Hippopotomonstrosesquippedaliophobia"
+            correct: true
+          - text: "Sesquipedalophobia"
+          - text: "Verbophobia"
+        labels: ["Language"]
+
+      - type: multiple-choice
+        q: "Which of these are real Guinness World Records?"
+        options:
+          - text: "Longest time balancing a lawnmower on chin"
+            correct: true
+          - text: "Most T-shirts worn at once (257)"
+            correct: true
+          - text: "Fastest 100m sprint while knitting"
+          - text: "Loudest burp (109.9 dB)"
+            correct: true
+        labels: ["Records"]
+
+      - q: "A group of pugs is called a 'grumble'."
+        a: "Yes, really. A grumble of pugs."
+        labels: ["Collective nouns"]
+        rel:
+          - ["grumble", "collective noun for a group of pugs"]
+          - ["pug", "small dog breed known for wrinkly face"]

--- a/public/lessons/english/open-learn-showcase/03-open-learn-feedback/content.yaml
+++ b/public/lessons/english/open-learn-showcase/03-open-learn-feedback/content.yaml
@@ -1,0 +1,131 @@
+version: 2
+number: 3
+title: "Open Learn — Your Feedback"
+description: "Help shape the future of Open Learn! Share your thoughts on this free, open, and extensible learning platform. Your answers are stored locally — and optionally shared with us if you enable it in Settings."
+
+sections:
+  - title: "First Impressions"
+    explanation: |
+      **Open Learn** is a free, open-source platform for learning anything — languages, science, trivia, you name it.
+
+      It's:
+      - **Free** — no ads, no subscriptions, no tracking
+      - **Open** — anyone can create and share workshops
+      - **Extensible** — load content from URLs, IPFS, or your own server
+      - **Offline-friendly** — runs as a static site, no backend needed
+
+      We'd love to hear what you think. Your answers are saved in your browser for you to revisit.
+      If you'd like to share them with us, enable "Share Answers with Coach" in Settings.
+    examples:
+      - type: select
+        q: "How did you discover Open Learn?"
+        options:
+          - text: "GitHub"
+          - text: "A friend or colleague shared it"
+          - text: "Social media"
+          - text: "Search engine"
+
+      - type: select
+        q: "What is your overall first impression?"
+        options:
+          - text: "Looks great, I want to use it!"
+          - text: "Interesting concept, needs more content"
+          - text: "I like it but the UI needs work"
+          - text: "Not sure yet, still exploring"
+
+      - type: input
+        q: "In one sentence — what do you think makes Open Learn different from other learning platforms?"
+
+  - title: "How Would You Use It?"
+    explanation: |
+      Open Learn is designed to be a **general-purpose learning platform**.
+      The same system that teaches Portuguese vocabulary can also teach:
+      - Math formulas
+      - Driver's license theory
+      - Pilot ground school
+      - Cooking techniques
+      - Music theory
+      - ...anything with a question/answer structure
+    examples:
+      - type: multiple-choice
+        q: "What would you most like to learn with Open Learn? (pick all that apply)"
+        options:
+          - text: "A new language"
+          - text: "Professional skills or certifications"
+          - text: "Fun trivia and general knowledge"
+          - text: "School or university material"
+
+      - type: select
+        q: "Would you create your own workshop content?"
+        options:
+          - text: "Yes, I'd love to create workshops for others"
+          - text: "Maybe, if there were a visual editor"
+          - text: "No, I prefer to consume content others create"
+          - text: "I'm not sure yet"
+
+      - type: input
+        q: "What specific topic would you love to see a workshop for?"
+
+  - title: "Features & Wishes"
+    explanation: |
+      We're always looking for ideas. Here's what Open Learn already supports:
+      - **Lessons** with sections, examples, and explanations
+      - **Audio playback** with adjustable speed
+      - **Progress tracking** via learning items
+      - **Video embeds** per section
+      - **Assessment types** (quizzes with text input, multiple choice, single select)
+      - **External content** loaded from any URL or IPFS
+      - **Dark mode** and customizable display settings
+      - **Coach forwarding** so workshop creators can receive answers
+
+      What else would make it better?
+    examples:
+      - type: multiple-choice
+        q: "Which features are most important to you? (pick all that apply)"
+        options:
+          - text: "Audio / pronunciation support"
+          - text: "Progress tracking and statistics"
+          - text: "Quizzes and self-assessment"
+          - text: "Mobile-friendly design"
+
+      - type: select
+        q: "How important is it that Open Learn stays completely free and open-source?"
+        options:
+          - text: "Essential — that's the main appeal"
+          - text: "Important, but I'd pay for premium features"
+          - text: "Doesn't matter much to me"
+          - text: "I'd prefer a polished paid product"
+
+      - type: input
+        q: "What feature do you wish Open Learn had that it doesn't have yet?"
+
+      - type: input
+        q: "Any other thoughts, ideas, or feedback? We're all ears!"
+
+  - title: "About You (Optional)"
+    explanation: |
+      Totally optional — but it helps us understand who uses Open Learn.
+    examples:
+      - type: select
+        q: "What best describes you?"
+        options:
+          - text: "Student"
+          - text: "Teacher or trainer"
+          - text: "Self-learner / hobbyist"
+          - text: "Developer or tech enthusiast"
+
+      - type: select
+        q: "How tech-savvy would you say you are?"
+        options:
+          - text: "I can edit YAML files and host a static site"
+          - text: "I'm comfortable with computers but not coding"
+          - text: "I just want to click and learn"
+          - text: "I'm a developer and could contribute to Open Learn"
+
+      - type: select
+        q: "Would you recommend Open Learn to someone?"
+        options:
+          - text: "Absolutely!"
+          - text: "Probably, once there's more content"
+          - text: "Maybe, depends on their needs"
+          - text: "Not yet, it needs more work"

--- a/public/lessons/english/open-learn-showcase/lessons.yaml
+++ b/public/lessons/english/open-learn-showcase/lessons.yaml
@@ -1,0 +1,4 @@
+lessons:
+  - 01-amazing-animal-facts
+  - 02-space-food-and-other-nonsense
+  - 03-open-learn-feedback

--- a/public/lessons/english/topics.yaml
+++ b/public/lessons/english/topics.yaml
@@ -1,0 +1,4 @@
+# Available topics for English interface
+topics:
+  - folder: open-learn-showcase
+    code: en-US

--- a/public/lessons/index.yaml
+++ b/public/lessons/index.yaml
@@ -3,3 +3,5 @@
 languages:
   - folder: deutsch
     code: de-DE
+  - folder: english
+    code: en-US


### PR DESCRIPTION
## Summary
Adds a complete English showcase workshop that demonstrates every Open Learn feature and collects user feedback about the platform.

**Topic:** `english/open-learn-showcase` (3 lessons)

### Lesson 1: Amazing Animal Facts
- Classic **Q&A examples** with fun animal trivia
- **Video embed** (YouTube, ocean creatures)
- **Markdown explanations** with formatting
- **Labels** (Anatomy, Survival, Brain, etc.)
- **Related items** (vocabulary/concept cards)

### Lesson 2: Space, Food & Other Nonsense
- **Input assessments** — type your answer (e.g., "What planet has the most moons?")
- **Select assessments** — pick one answer (radio buttons)
- **Multiple-choice assessments** — pick all correct answers (checkboxes)
- Mixed with regular Q&A for fun facts
- Correct answer validation with immediate feedback

### Lesson 3: Open Learn Feedback
- Collects real user opinions about Open Learn
- First impressions, feature wishes, usage patterns, demographics
- All assessment types (input, select, multiple-choice)
- Answers stored locally, optionally shareable via coach forwarding

## Features demonstrated
- [x] Q&A examples (classic)
- [x] Video embeds per section
- [x] Markdown explanations
- [x] Labels on examples
- [x] Related items (learning items)
- [x] Input assessment (free text)
- [x] Multiple-choice assessment (checkboxes)
- [x] Select assessment (radio buttons)
- [x] Answer validation with correct/incorrect feedback
- [x] Multiple accepted answers (synonyms)
- [x] English as second interface language

## Test plan
- [ ] Select "English" on home page, see "Open Learn Showcase" topic
- [ ] Open Lesson 1: verify video plays, Q&A works, labels and related items show
- [ ] Open Lesson 2: test all three assessment types, verify answer persistence
- [ ] Open Lesson 3: fill out feedback, navigate away, come back — answers restored
- [ ] Run `pnpm test` — all 34 tests pass