### PR TITLE
feat: batch coach forwarding and reference coach server

### DIFF
--- a/examples/coach-server/.gitignore
+++ b/examples/coach-server/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+data/
+dist/

--- a/examples/coach-server/README.md
+++ b/examples/coach-server/README.md
@@ -1,0 +1,112 @@
+# Open Learn Coach Server
+
+Reference implementation of a coach server that receives assessment answers from Open Learn workshops and stores them as structured Markdown files.
+
+## Quick Start
+
+```bash
+cd examples/coach-server
+npm install
+npm run dev
+```
+
+The server starts at `http://localhost:3001`.
+
+## Configure Your Workshop
+
+Add the coach API to your lesson's `content.yaml`:
+
+```yaml
+version: 2
+title: "My Workshop"
+coach:
+  api: "http://localhost:3001/api/answers"
+  name: "Workshop Coach"
+sections:
+  # ...
+```
+
+Users need to enable "Share Answers with Coach" in Open Learn Settings.
+
+## How It Works
+
+1. Users answer assessment questions in Open Learn
+2. Answers are collected in a batch (not sent individually)
+3. The batch is sent when the user clicks "Send Answers to Coach", navigates away, or closes the tab
+4. This server receives the batch and writes a Markdown file
+
+## File Structure
+
+```
+data/
+├── english-open-learn-showcase/     # Workshop ID
+│   ├── anonymous/                    # User ID (or email)
+│   │   ├── index.md                  # Summary of all submissions
+│   │   ├── 2026-02-19_10-30-00.md   # Individual submission
+│   │   └── 2026-02-19_11-00-00.md
+│   └── user@example.com/
+│       ├── index.md
+│       └── 2026-02-19_10-45-00.md
+```
+
+Each submission is a readable Markdown file:
+
+```markdown
+# Open Learn Feedback
+
+- **Workshop:** english / open-learn-showcase
+- **Lesson:** 3
+- **User:** user@example.com
+- **Submitted:** 2026-02-19T10:30:00.000Z
+
+---
+
+## First Impressions
+
+**How did you discover Open Learn?**
+
+> GitHub
+
+**What is your overall first impression?**
+
+> Looks great, I want to use it!
+```
+
+## API
+
+### `POST /api/answers`
+
+Receives a batch of answers.
+
+**Request body:**
+
+```json
+{
+  "lesson": {
+    "learning": "english",
+    "teaching": "open-learn-showcase",
+    "number": 3,
+    "title": "Open Learn Feedback"
+  },
+  "answers": [
+    {
+      "section": { "index": 0, "title": "First Impressions" },
+      "example": { "index": 0, "type": "select", "question": "How did you discover Open Learn?" },
+      "answer": { "value": 0, "correct": null }
+    }
+  ],
+  "user": "optional@email.com",
+  "timestamp": "2026-02-19T10:30:00.000Z"
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true, "count": 1 }
+```
+
+**Error responses:**
+- `400` — Invalid payload
+- `401` — Unauthorized (implement your own auth logic)
+- `500` — Storage error

--- a/examples/coach-server/package.json
+++ b/examples/coach-server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "open-learn-coach-server",
+  "version": "1.0.0",
+  "description": "Reference coach server for Open Learn — receives batched assessment answers and stores them as structured Markdown files",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "tsx src/server.ts"
+  },
+  "dependencies": {
+    "express": "^4.21.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/coach-server/src/server.ts
+++ b/examples/coach-server/src/server.ts
@@ -1,0 +1,79 @@
+import express from "express";
+import { writeAnswersToMarkdown } from "./storage.js";
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+// Parse JSON body (including from sendBeacon which sends as blob)
+app.use(express.json({ type: ["application/json", "text/plain"] }));
+
+// CORS — allow requests from any origin (Open Learn is a static site)
+app.use((_req, res, next) => {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Content-Type");
+  res.header("Access-Control-Allow-Methods", "POST, OPTIONS");
+  next();
+});
+
+// Handle preflight
+app.options("/api/answers", (_req, res) => {
+  res.sendStatus(204);
+});
+
+// Receive batched answers
+app.post("/api/answers", (req, res) => {
+  const { lesson, answers, user, timestamp } = req.body;
+
+  if (!lesson || !answers || !Array.isArray(answers) || answers.length === 0) {
+    res.status(400).json({ error: "Invalid payload: lesson and answers[] required" });
+    return;
+  }
+
+  const workshopId = `${lesson.learning}-${lesson.teaching}`;
+  const userId = user || "anonymous";
+
+  try {
+    const filePath = writeAnswersToMarkdown(workshopId, userId, {
+      lesson,
+      answers,
+      user: user || undefined,
+      timestamp: timestamp || new Date().toISOString(),
+    });
+
+    console.log(
+      `[${new Date().toISOString()}] Received ${answers.length} answers from "${userId}" for "${lesson.title}" → ${filePath}`
+    );
+
+    res.json({ ok: true, count: answers.length });
+  } catch (err) {
+    console.error("Failed to write answers:", err);
+    res.status(500).json({ error: "Failed to store answers" });
+  }
+});
+
+// Simple dashboard: list all stored files
+app.get("/", (_req, res) => {
+  res.send(`
+    <html>
+      <head><title>Open Learn Coach Server</title></head>
+      <body style="font-family: system-ui; max-width: 600px; margin: 2rem auto; padding: 0 1rem;">
+        <h1>Open Learn Coach Server</h1>
+        <p>This server receives assessment answers from Open Learn workshops.</p>
+        <p>Answers are stored as Markdown files in <code>./data/</code></p>
+        <h2>API</h2>
+        <pre>POST /api/answers</pre>
+        <p>Configure in your lesson YAML:</p>
+        <pre>coach:
+  api: "http://localhost:${PORT}/api/answers"
+  name: "My Workshop"</pre>
+        <h2>Files</h2>
+        <p>Check the <code>data/</code> folder for received answers.</p>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(PORT, () => {
+  console.log(`Coach server running at http://localhost:${PORT}`);
+  console.log(`Configure in lesson YAML: coach.api = "http://localhost:${PORT}/api/answers"`);
+});

--- a/examples/coach-server/src/storage.ts
+++ b/examples/coach-server/src/storage.ts
@@ -1,0 +1,139 @@
+import { mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DATA_DIR = join(process.cwd(), "data");
+
+interface Answer {
+  section: { index: number; title?: string };
+  example: { index: number; type: string; question: string };
+  answer: { value: string | number | number[]; correct: boolean | null };
+}
+
+interface AnswerBatch {
+  lesson: {
+    learning: string;
+    teaching: string;
+    number: number;
+    title: string;
+  };
+  answers: Answer[];
+  user?: string;
+  timestamp: string;
+}
+
+function sanitizePath(str: string): string {
+  return str.replace(/[^a-zA-Z0-9._@-]/g, "_");
+}
+
+function formatTimestamp(iso: string): string {
+  return iso.replace(/[:.]/g, "-").replace("T", "_").replace("Z", "");
+}
+
+function formatAnswerValue(value: string | number | number[]): string {
+  if (Array.isArray(value)) {
+    return value.map((v) => `Option ${v}`).join(", ");
+  }
+  if (typeof value === "number") {
+    return `Option ${value}`;
+  }
+  return value;
+}
+
+function renderMarkdown(batch: AnswerBatch): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${batch.lesson.title}`);
+  lines.push("");
+  lines.push(`- **Workshop:** ${batch.lesson.learning} / ${batch.lesson.teaching}`);
+  lines.push(`- **Lesson:** ${batch.lesson.number}`);
+  lines.push(`- **User:** ${batch.user || "anonymous"}`);
+  lines.push(`- **Submitted:** ${batch.timestamp}`);
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  // Group answers by section
+  const bySection = new Map<number, Answer[]>();
+  for (const answer of batch.answers) {
+    const sIdx = answer.section.index;
+    if (!bySection.has(sIdx)) {
+      bySection.set(sIdx, []);
+    }
+    bySection.get(sIdx)!.push(answer);
+  }
+
+  for (const [sectionIdx, answers] of bySection) {
+    const sectionTitle = answers[0]?.section.title || `Section ${sectionIdx + 1}`;
+    lines.push(`## ${sectionTitle}`);
+    lines.push("");
+
+    for (const answer of answers) {
+      lines.push(`**${answer.example.question}**`);
+      lines.push("");
+      lines.push(`> ${formatAnswerValue(answer.answer.value)}`);
+      lines.push("");
+
+      if (answer.answer.correct === true) {
+        lines.push("*Correct*");
+      } else if (answer.answer.correct === false) {
+        lines.push("*Incorrect*");
+      }
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Write a batch of answers to a Markdown file.
+ *
+ * File structure:
+ *   data/{workshopId}/{userId}/{timestamp}.md
+ *
+ * Also maintains a summary index per user:
+ *   data/{workshopId}/{userId}/index.md
+ */
+export function writeAnswersToMarkdown(
+  workshopId: string,
+  userId: string,
+  batch: AnswerBatch
+): string {
+  const safeWorkshop = sanitizePath(workshopId);
+  const safeUser = sanitizePath(userId);
+  const dir = join(DATA_DIR, safeWorkshop, safeUser);
+
+  mkdirSync(dir, { recursive: true });
+
+  // Write individual submission
+  const filename = `${formatTimestamp(batch.timestamp)}.md`;
+  const filePath = join(dir, filename);
+  const markdown = renderMarkdown(batch);
+  writeFileSync(filePath, markdown, "utf-8");
+
+  // Update user index
+  updateUserIndex(dir, safeUser, batch, filename);
+
+  return filePath;
+}
+
+function updateUserIndex(
+  dir: string,
+  userId: string,
+  batch: AnswerBatch,
+  filename: string
+): void {
+  const indexPath = join(dir, "index.md");
+  let content = "";
+
+  if (existsSync(indexPath)) {
+    content = readFileSync(indexPath, "utf-8");
+  } else {
+    content = `# Submissions: ${userId}\n\n`;
+  }
+
+  const entry = `- **${batch.timestamp}** — Lesson ${batch.lesson.number}: ${batch.lesson.title} (${batch.answers.length} answers) → [${filename}](./${filename})\n`;
+  content += entry;
+
+  writeFileSync(indexPath, content, "utf-8");
+}

--- a/examples/coach-server/tsconfig.json
+++ b/examples/coach-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

### Client: Batch forwarding instead of individual requests
- Answers are **queued** during a lesson instead of sent immediately
- Batch is flushed via:
  - **Manual button** "Send Answers to Coach (N)" at end of lesson
  - **Navigation** away from lesson (onBeforeUnmount, router link clicks)
  - **Tab/window close** (beforeunload via sendBeacon)
- Button shows queue count, disables when empty, shows "Sent!" on success
- Coach rejection notice (401 + enroll URL) shown at lesson end

### New lesson footer buttons
- **Send Answers to Coach** — only visible when coach configured + consent enabled
- **Next Lesson** — navigates to next lesson (if exists)
- **All Lessons** — back to lessons overview

### Reference coach server (`examples/coach-server/`)
- Node + TypeScript + Express
- `POST /api/answers` receives batched answers
- Stores as structured **Markdown files**: `data/{workshop}/{user}/{timestamp}.md`
- Per-user `index.md` with submission history
- No database, just files — easy to browse, version control, or process

### Batch API payload
```json
{
  "lesson": { "learning": "english", "teaching": "open-learn-showcase", "number": 3, "title": "..." },
  "answers": [
    { "section": { "index": 0, "title": "..." }, "example": { "index": 0, "type": "select", "question": "..." }, "answer": { "value": 1, "correct": null } }
  ],
  "user": "optional@email.com",
  "timestamp": "2026-02-19T..."
}
```

## Test plan
- [ ] Submit answers in a lesson — verify they queue (button shows count)
- [ ] Click "Send Answers to Coach" — verify batch POST sent, button shows "Sent!"
- [ ] Navigate away — verify flush on leave
- [ ] Test with `examples/coach-server`: `cd examples/coach-server && npm install && npm run dev`
- [ ] Verify Markdown files in `data/` folder
- [ ] Run `pnpm test` — all 35 tests pass