### PR TITLE
feat: add per-topic export/import of user data

### DIFF
--- a/src/composables/useAssessments.js
+++ b/src/composables/useAssessments.js
@@ -196,6 +196,22 @@ function initializeWatchers() {
   }, { deep: true })
 }
 
+// Return raw assessments object
+function getAssessments() {
+  return assessments.value
+}
+
+// Merge imported assessments into existing (additive)
+function mergeAssessments(imported) {
+  for (const [lessonKey, answers] of Object.entries(imported)) {
+    if (!assessments.value[lessonKey]) {
+      assessments.value[lessonKey] = {}
+    }
+    Object.assign(assessments.value[lessonKey], answers)
+  }
+  saveAssessments()
+}
+
 export function useAssessments() {
   initializeWatchers()
 
@@ -211,6 +227,8 @@ export function useAssessments() {
     hasQueuedAnswers,
     flushCoachQueue,
     flushCoachQueueSync,
-    clearCoachQueue
+    clearCoachQueue,
+    getAssessments,
+    mergeAssessments
   }
 }

--- a/src/composables/useProgress.js
+++ b/src/composables/useProgress.js
@@ -76,6 +76,22 @@ function initializeWatchers() {
   }, { deep: true })
 }
 
+// Return raw progress object
+function getProgress() {
+  return progress.value
+}
+
+// Merge imported progress into existing (additive)
+function mergeProgress(imported) {
+  for (const [topicKey, items] of Object.entries(imported)) {
+    if (!progress.value[topicKey]) {
+      progress.value[topicKey] = {}
+    }
+    Object.assign(progress.value[topicKey], items)
+  }
+  saveProgress()
+}
+
 export function useProgress() {
   // Initialize watchers on first use
   initializeWatchers()
@@ -85,6 +101,8 @@ export function useProgress() {
     loadProgress,
     isItemLearned,
     toggleItemLearned,
-    areAllItemsLearned
+    areAllItemsLearned,
+    getProgress,
+    mergeProgress
   }
 }

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -219,11 +219,177 @@
           placeholder="your@email.com or username" />
       </div>
     </div>
+    <!-- Data Section -->
+    <div class="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg">
+      <h2 class="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-6 pb-3 border-b-2 border-gray-300 dark:border-gray-600">
+        Data
+      </h2>
+
+      <div v-if="availableTopics.length === 0" class="text-gray-600 dark:text-gray-400 text-sm mb-4">
+        No data yet. Start learning to track your progress.
+      </div>
+
+      <template v-else>
+        <!-- Topic selector -->
+        <div class="mb-4">
+          <label class="block font-semibold text-gray-800 dark:text-gray-200 mb-2 text-lg">
+            Topic
+          </label>
+          <div class="flex gap-2 flex-wrap">
+            <button
+              v-for="topic in availableTopics"
+              :key="topic.key"
+              @click="selectedTopic = topic.key"
+              :class="[
+                'px-3 py-1.5 rounded font-semibold transition text-sm',
+                selectedTopic === topic.key
+                  ? 'bg-primary-500 text-white'
+                  : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600'
+              ]">
+              {{ topic.label }}
+            </button>
+          </div>
+        </div>
+
+        <div class="text-gray-600 dark:text-gray-400 text-sm mb-4">
+          {{ dataSummary }}
+        </div>
+
+        <div class="flex gap-3 flex-wrap">
+          <button
+            @click="exportData"
+            class="px-4 py-2 rounded font-semibold transition bg-primary-500 text-white hover:bg-primary-600">
+            Export
+          </button>
+
+          <button
+            @click="$refs.fileInput.click()"
+            class="px-4 py-2 rounded font-semibold transition bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600">
+            Import
+          </button>
+          <input
+            ref="fileInput"
+            type="file"
+            accept=".json"
+            class="hidden"
+            @change="importData" />
+        </div>
+      </template>
+
+      <div v-if="importMessage" class="mt-3 text-sm" :class="importMessageError ? 'text-red-500' : 'text-green-600 dark:text-green-400'">
+        {{ importMessage }}
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
+import { computed, ref } from 'vue'
 import { useSettings } from '../composables/useSettings'
+import { useProgress } from '../composables/useProgress'
+import { useAssessments } from '../composables/useAssessments'
+import { formatLangName } from '../utils/formatters'
 
 const { settings } = useSettings()
+const { progress, getProgress, mergeProgress } = useProgress()
+const { assessments, getAssessments, mergeAssessments } = useAssessments()
+
+const importMessage = ref('')
+const importMessageError = ref(false)
+const selectedTopic = ref('')
+
+// Collect all unique topic keys (learning:teaching) from progress + assessments
+const availableTopics = computed(() => {
+  const keys = new Set()
+  for (const key of Object.keys(progress.value)) {
+    keys.add(key) // progress keys are "learning:teaching"
+  }
+  for (const key of Object.keys(assessments.value)) {
+    // assessment keys are "learning:teaching:lessonNumber"
+    const parts = key.split(':')
+    if (parts.length >= 2) keys.add(`${parts[0]}:${parts[1]}`)
+  }
+  const sorted = [...keys].sort()
+  // Auto-select first topic if none selected
+  if (sorted.length > 0 && !sorted.includes(selectedTopic.value)) {
+    selectedTopic.value = sorted[0]
+  }
+  return sorted.map(key => {
+    const [learning, teaching] = key.split(':')
+    return { key, label: formatLangName(teaching) }
+  })
+})
+
+// Filter progress/assessments for the selected topic
+function getTopicProgress() {
+  const all = getProgress()
+  return all[selectedTopic.value] ? { [selectedTopic.value]: all[selectedTopic.value] } : {}
+}
+
+function getTopicAssessments() {
+  const all = getAssessments()
+  const prefix = selectedTopic.value + ':'
+  const filtered = {}
+  for (const [key, val] of Object.entries(all)) {
+    if (key.startsWith(prefix)) filtered[key] = val
+  }
+  return filtered
+}
+
+const dataSummary = computed(() => {
+  if (!selectedTopic.value) return ''
+  const topicProgress = progress.value[selectedTopic.value] || {}
+  const itemCount = Object.keys(topicProgress).length
+  const prefix = selectedTopic.value + ':'
+  let answerCount = 0
+  for (const [key, answers] of Object.entries(assessments.value)) {
+    if (key.startsWith(prefix)) answerCount += Object.keys(answers).length
+  }
+  return `${itemCount} item${itemCount !== 1 ? 's' : ''} learned, ${answerCount} answer${answerCount !== 1 ? 's' : ''}`
+})
+
+function exportData() {
+  const data = {
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    topic: selectedTopic.value,
+    progress: getTopicProgress(),
+    assessments: getTopicAssessments()
+  }
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const date = new Date().toISOString().slice(0, 10)
+  const topicSlug = selectedTopic.value.replace(/:/g, '-')
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `open-learn-${topicSlug}-${date}.json`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function importData(event) {
+  const file = event.target.files[0]
+  if (!file) return
+
+  const reader = new FileReader()
+  reader.onload = (e) => {
+    try {
+      const data = JSON.parse(e.target.result)
+      if (!data.version || (!data.progress && !data.assessments)) {
+        importMessage.value = 'Invalid file format.'
+        importMessageError.value = true
+        return
+      }
+      if (data.progress) mergeProgress(data.progress)
+      if (data.assessments) mergeAssessments(data.assessments)
+      importMessage.value = 'Data imported successfully.'
+      importMessageError.value = false
+    } catch {
+      importMessage.value = 'Could not read file.'
+      importMessageError.value = true
+    }
+  }
+  reader.readAsText(file)
+  event.target.value = ''
+}
 </script>


### PR DESCRIPTION
## Summary
- Add export/import functionality to Settings page for transferring learning progress and assessment answers between browsers/devices
- Data is scoped per topic (e.g. Portugiesisch, Spanisch) — users select which topic to export
- Import merges additively into existing data (no data lost)

## Changes
- `useProgress.js`: add `getProgress()` and `mergeProgress()` helpers
- `useAssessments.js`: add `getAssessments()` and `mergeAssessments()` helpers
- `Settings.vue`: add Data section with topic selector, export/import buttons, and summary stats

## Test plan
- [x] `pnpm test` — all 35 tests pass
- [ ] Export data, verify JSON file downloads with correct per-topic content
- [ ] Import in another browser/profile, verify progress and answers restored
- [ ] Import with existing data, verify merge (no data lost)