### PR TITLE
feat: shareable workshop URLs via copy-link button

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -65,14 +65,15 @@
                   {{ getTopicSourceLabel(topic) }}
                 </div>
               </div>
-              <div v-if="isRemoteTopic(topic)" class="flex items-center gap-1 flex-shrink-0">
+              <div class="flex items-center gap-1 flex-shrink-0">
                 <button
-                  @click.stop="copyShareLink(topic)"
+                  @click.stop="copyWorkshopLink(topic)"
                   class="p-1.5 rounded text-gray-400 hover:text-primary-500 hover:bg-gray-100 dark:hover:bg-gray-600 transition"
-                  title="Copy share link">
+                  title="Copy link to workshop">
                   <span class="text-sm">{{ copiedTopic === topic ? '✓' : '🔗' }}</span>
                 </button>
                 <button
+                  v-if="isRemoteTopic(topic)"
                   @click.stop="removeSource(topic)"
                   class="p-1.5 rounded text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900 transition"
                   title="Remove external source">
@@ -133,7 +134,7 @@ import { useLessons } from '../composables/useLessons'
 import { formatLangName } from '../utils/formatters'
 
 const router = useRouter()
-const { availableContent, isLoading, loadAvailableContent, loadTopicsForLanguage, removeContentSource, isRemoteTopic, getSourceForSlug, getTopicMeta, getShareUrl, getContentSources } = useLessons()
+const { availableContent, isLoading, loadAvailableContent, loadTopicsForLanguage, removeContentSource, isRemoteTopic, getSourceForSlug, getTopicMeta, getContentSources } = useLessons()
 
 const selectedLearning = ref(null)
 const selectedTeaching = ref(null)
@@ -186,9 +187,9 @@ function getTopicSourceLabel(topic) {
   }
 }
 
-async function copyShareLink(topic) {
-  const url = getShareUrl(topic)
-  if (!url) return
+async function copyWorkshopLink(topic) {
+  const base = window.location.href.replace(/#.*$/, '')
+  const url = `${base}#/${selectedLearning.value}/${topic}/lessons`
   try {
     await navigator.clipboard.writeText(url)
     copiedTopic.value = topic

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -62,7 +62,7 @@ const router = useRouter()
 const route = useRoute()
 const emit = defineEmits(['update-title'])
 
-const { loadAllLessonsForTopic, isRemoteTopic, getSourceForSlug, getTopicMeta, getShareUrl } = useLessons()
+const { loadAllLessonsForTopic, isRemoteTopic, getSourceForSlug, getTopicMeta } = useLessons()
 
 const lessons = ref([])
 const isLoading = ref(true)
@@ -87,8 +87,8 @@ const sourceLabel = computed(() => {
 })
 
 async function copyShareLink() {
-  const url = getShareUrl(teaching.value)
-  if (!url) return
+  const base = window.location.href.replace(/#.*$/, '')
+  const url = `${base}#/${learning.value}/${teaching.value}/lessons`
   try {
     await navigator.clipboard.writeText(url)
     copied.value = true


### PR DESCRIPTION
## Summary
- Replace add-source share links with direct workshop navigation URLs
- Every topic card on the Home page now shows a copy-link button (not just remote topics)
- Copies direct URL like `https://felixboehm.github.io/open-learn/#/deutsch/portugiesisch/lessons`
- LessonsOverview share button also copies the direct navigation URL

## Test plan
- [x] `pnpm test` — all 35 tests pass
- [ ] Click copy button on topic card, verify URL navigates directly to workshop
- [ ] Click share button on LessonsOverview, verify same direct URL