### PR TITLE
Replace coach queue/batch sending with assessment results review page

### DIFF
--- a/docs/lesson-schema.md
+++ b/docs/lesson-schema.md
@@ -71,9 +71,6 @@ version: 2                          # Lesson format version (integer, optional)
 number: 1                           # Lesson number (integer)
 title: "Lesson Title"               # Lesson title (string)
 description: "Brief description"    # Optional lesson description
-coach:                              # Optional: coach API for answer forwarding
-  api: "https://coach.example.com/api/answers"
-  name: "Coach Name"                # Optional: displayed in UI
 sections: [...]                     # Array of sections (see below)
 ```
 
@@ -83,37 +80,6 @@ sections: [...]                     # Array of sections (see below)
 - Used to track lesson format changes and ensure compatibility
 - Version 1 content is fully backward compatible
 - If omitted, assumed to be version 1
-
-### Coach Configuration (Optional)
-
-The `coach` field enables answer forwarding to a workshop coach's server:
-
-- **api** (string, required): HTTP endpoint that receives POST requests with answer data
-- **name** (string, optional): Coach or workshop name displayed in the UI
-
-The user must opt-in via Settings > Workshop > "Share Answers with Coach" before any data is sent. Users can optionally provide an email/username for identification.
-
-**API Contract — `POST {coach.api}`:**
-
-```json
-{
-  "lesson": {
-    "learning": "deutsch",
-    "teaching": "portugiesisch",
-    "number": 1,
-    "title": "Lesson Title"
-  },
-  "section": { "index": 0, "title": "Section Title" },
-  "example": { "index": 0, "type": "input", "question": "Translate: ..." },
-  "answer": { "value": "user's answer", "correct": true },
-  "user": "user@example.com",
-  "timestamp": "2026-02-19T10:30:00.000Z"
-}
-```
-
-- `user` is only included if the user provided an identifier in settings
-- `answer.correct` is `null` if no correct answer is defined
-- Coach can return `401` to reject unauthorized users; optionally include `{ "enrollUrl": "https://..." }` in the response body
 
 ### Section Structure
 

--- a/docs/yaml-schemas.md
+++ b/docs/yaml-schemas.md
@@ -120,8 +120,14 @@ topics:
   - string                      # Backward compatible: folder name
   - folder: string              # Local folder source
     code: string
+    coach:                      # Optional: workshop coach
+      email: string
+      name: string
   - url: string                 # Remote URL source (HTTP/HTTPS/IPFS)
     code: string
+    coach:                      # Optional: workshop coach
+      email: string
+      name: string
 ```
 
 ### Fields
@@ -131,11 +137,17 @@ topics:
   - **Object format with `folder`**:
     - **folder** (string, required): Directory name for this topic (e.g., "portugiesisch", "math-algebra")
     - **code** (string, optional): Language/locale code for text-to-speech (BCP 47 format)
+    - **coach** (object, optional): Workshop coach configuration
+      - **email** (string, required): Coach's email address for `mailto:` results
+      - **name** (string, optional): Coach or workshop name displayed in the UI
   - **Object format with `url`**:
     - **url** (string, required): Remote URL to the topic folder
     - **code** (string, optional): Language/locale code for text-to-speech
+    - **coach** (object, optional): Workshop coach configuration (same fields as above)
 
 For language topics, use the target language code (e.g., "pt-PT" for Portuguese). For non-language topics, use the base language code.
+
+When `coach` is configured, the Assessment Results page (`/:learning/:teaching/results`) shows a "Send Results via Email" button that opens the user's email client with a plain-text report.
 
 ### Example
 
@@ -143,9 +155,11 @@ For language topics, use the target language code (e.g., "pt-PT" for Portuguese)
 # Available topics for German language
 # This file lists all topics available in the German interface
 topics:
-  # Object format with folder
+  # Object format with folder + coach
   - folder: portugiesisch
     code: pt-PT
+    coach:
+      email: "coach@example.com"
 
   # String format (backward compatible)
   - englisch

--- a/public/lessons/deutsch/topics.yaml
+++ b/public/lessons/deutsch/topics.yaml
@@ -3,3 +3,5 @@
 topics:
   - folder: portugiesisch
     code: pt-PT
+    coach:
+      email: "open-learn@felixboehm.it"

--- a/public/lessons/english/topics.yaml
+++ b/public/lessons/english/topics.yaml
@@ -2,3 +2,5 @@
 topics:
   - folder: open-learn-showcase
     code: en-US
+    coach:
+      email: "open-learn@felixboehm.it"

--- a/src/composables/useLessons.js
+++ b/src/composables/useLessons.js
@@ -19,10 +19,10 @@ function parseSource(source) {
   }
   if (typeof source === 'object') {
     if (source.folder) {
-      return { type: 'folder', path: source.folder, code: source.code, title: source.title || null, description: source.description || null }
+      return { type: 'folder', path: source.folder, code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null }
     }
     if (source.url) {
-      return { type: 'url', path: resolveUrl(source.url), code: source.code, title: source.title || null, description: source.description || null }
+      return { type: 'url', path: resolveUrl(source.url), code: source.code, title: source.title || null, description: source.description || null, coach: source.coach || null }
     }
   }
   return null
@@ -168,7 +168,8 @@ export function useLessons() {
             }
             topicMeta.value[langKey][slug] = {
               title: topicSource.title || null,
-              description: topicSource.description || null
+              description: topicSource.description || null,
+              coach: topicSource.coach || null
             }
 
             console.log(`  ✓ Remote topic: ${slug} → ${topicUrl} (${topicSource.code || 'no code'})`)
@@ -286,7 +287,8 @@ export function useLessons() {
         }
         topicMeta.value[lang][key] = {
           title: source.title || null,
-          description: source.description || null
+          description: source.description || null,
+          coach: source.coach || null
         }
 
         console.log(`  ✓ Topic: ${key} (${source.type}) (${source.code || 'no code'})`)

--- a/src/composables/useSettings.js
+++ b/src/composables/useSettings.js
@@ -9,9 +9,7 @@ const settings = ref({
   audioSpeed: 1.0, // Audio playback speed: 0.6, 0.8, 1.0
   readAnswers: true, // Whether to read the answer/translation during auto-play
   hideLearnedExamples: true, // Whether to hide examples where all items are learned
-  showDebugOverlay: false, // Show debug overlay for audio playback
-  coachConsent: false, // Global consent to forward answers to coach APIs
-  coachIdentifier: '' // Optional email/username for coach identification
+  showDebugOverlay: false // Show debug overlay for audio playback
 })
 
 let isInitialized = false
@@ -84,14 +82,6 @@ function initializeWatchers() {
   })
 
   watch(() => settings.value.showDebugOverlay, () => {
-    saveSettings()
-  })
-
-  watch(() => settings.value.coachConsent, () => {
-    saveSettings()
-  })
-
-  watch(() => settings.value.coachIdentifier, () => {
     saveSettings()
   })
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import Home from '../views/Home.vue'
 import LessonsOverview from '../views/LessonsOverview.vue'
 import LessonDetail from '../views/LessonDetail.vue'
 import LearningItems from '../views/LearningItems.vue'
+import AssessmentResults from '../views/AssessmentResults.vue'
 import Settings from '../views/Settings.vue'
 import AddSource from '../views/AddSource.vue'
 
@@ -29,6 +30,12 @@ const routes = [
     path: '/:learning/:teaching/items/:number?',
     name: 'learning-items',
     component: LearningItems,
+    meta: { title: null } // Will be set dynamically
+  },
+  {
+    path: '/:learning/:teaching/results',
+    name: 'assessment-results',
+    component: AssessmentResults,
     meta: { title: null } // Will be set dynamically
   },
   {

--- a/src/views/AssessmentResults.vue
+++ b/src/views/AssessmentResults.vue
@@ -1,0 +1,322 @@
+<template>
+  <div>
+    <div v-if="!isLoading && lessons.length > 0">
+      <!-- Lesson filter -->
+      <div v-if="lessons.length > 1" class="flex flex-wrap gap-2 mb-5">
+        <button
+          @click="selectedLesson = null"
+          :class="[
+            'px-3 py-1.5 rounded font-semibold transition text-sm',
+            selectedLesson === null
+              ? 'bg-primary-500 text-white'
+              : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600'
+          ]">
+          All Lessons
+        </button>
+        <button
+          v-for="lesson in lessons"
+          :key="lesson.number"
+          @click="selectedLesson = lesson.number"
+          :class="[
+            'px-3 py-1.5 rounded font-semibold transition text-sm',
+            selectedLesson === lesson.number
+              ? 'bg-primary-500 text-white'
+              : 'bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600'
+          ]">
+          {{ lesson.number }}
+        </button>
+      </div>
+
+      <!-- Summary header -->
+      <div class="bg-gray-100 dark:bg-gray-800 rounded-lg p-5 mb-6">
+        <div class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
+          {{ totalAnswered }} of {{ totalAssessments }} assessments answered
+        </div>
+        <div class="text-sm text-gray-600 dark:text-gray-400">
+          {{ totalCorrect }} correct, {{ totalWrong }} incorrect, {{ totalUnanswered }} missing
+        </div>
+        <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+          {{ totalLearnedItems }} learning items marked as learned
+        </div>
+      </div>
+
+      <!-- Per-lesson cards -->
+      <div v-for="entry in filteredEntries" :key="entry.lesson.number" class="border-2 border-gray-200 dark:border-gray-700 rounded-lg p-5 mb-5 bg-white dark:bg-gray-800">
+        <h3 class="text-xl font-bold text-gray-800 dark:text-gray-200 mb-1">
+          Lesson {{ entry.lesson.number }}: {{ entry.lesson.title }}
+        </h3>
+
+        <!-- Learning items stats -->
+        <div v-if="entry.totalItems > 0" class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+          {{ entry.learnedItems }}/{{ entry.totalItems }} learning items learned
+        </div>
+
+        <!-- Assessment answers per section -->
+        <div v-for="section in entry.sections" :key="section.index" class="mb-4">
+          <div class="font-semibold text-primary-500 dark:text-blue-400 mb-2">{{ section.title }}</div>
+
+          <div v-for="ex in section.examples" :key="ex.key" class="ml-4 mb-1 text-sm">
+            <template v-if="ex.answered">
+              <span v-if="ex.correct === true" class="text-green-600 dark:text-green-400 font-mono">[ok]</span>
+              <span v-else-if="ex.correct === false" class="text-red-600 dark:text-red-400 font-mono">[!!]</span>
+              <span v-else class="text-gray-500 font-mono">[--]</span>
+              <span class="text-gray-800 dark:text-gray-200 ml-1">{{ ex.question }}</span>
+              <span class="text-gray-500 mx-1">&rarr;</span>
+              <span class="text-gray-700 dark:text-gray-300 italic">{{ ex.displayAnswer }}</span>
+              <span v-if="ex.correct === false && ex.expected" class="text-red-500 dark:text-red-400 ml-1">(expected: {{ ex.expected }})</span>
+            </template>
+            <template v-else>
+              <span class="text-gray-400 font-mono">[  ]</span>
+              <span class="text-gray-500 ml-1">{{ ex.question }}</span>
+              <span class="text-gray-400 ml-1">(not answered)</span>
+            </template>
+          </div>
+        </div>
+
+        <!-- No assessments in this lesson -->
+        <div v-if="entry.assessmentCount === 0" class="text-sm text-gray-400 italic">
+          No assessments in this lesson
+        </div>
+      </div>
+
+      <!-- Send to coach button -->
+      <div v-if="coachEmail" class="border-2 border-gray-200 dark:border-gray-700 rounded-lg p-5 mb-5 bg-white dark:bg-gray-800">
+        <div class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+          Send your results to <strong class="text-gray-800 dark:text-gray-200">{{ coachName || coachEmail }}</strong> via email.
+        </div>
+        <a
+          :href="mailtoLink"
+          class="inline-block px-5 py-3 bg-green-600 text-white rounded-lg font-semibold hover:bg-green-700 transition">
+          Send Results via Email
+        </a>
+      </div>
+    </div>
+
+    <!-- Loading state -->
+    <div v-else-if="isLoading" class="text-center py-8">
+      <div class="text-2xl font-bold text-primary-500 dark:text-blue-400 mb-4">
+        Loading results...
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else class="text-center py-8">
+      <div class="text-xl text-gray-600 dark:text-gray-400">
+        No lessons found
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { useLessons } from '../composables/useLessons'
+import { useAssessments } from '../composables/useAssessments'
+import { useProgress } from '../composables/useProgress'
+import { formatLangName } from '../utils/formatters'
+
+const route = useRoute()
+const emit = defineEmits(['update-title'])
+
+const { loadAllLessonsForTopic, getTopicMeta } = useLessons()
+const { getAnswer } = useAssessments()
+const { isItemLearned } = useProgress()
+
+const lessons = ref([])
+const isLoading = ref(true)
+const selectedLesson = ref(null)
+
+const learning = computed(() => route.params.learning)
+const teaching = computed(() => route.params.teaching)
+
+// Coach info from topic metadata
+const coachEmail = computed(() => {
+  const meta = getTopicMeta(learning.value, teaching.value)
+  return meta.coach?.email || null
+})
+
+const coachName = computed(() => {
+  const meta = getTopicMeta(learning.value, teaching.value)
+  return meta.coach?.name || null
+})
+
+// Build structured data for each lesson
+const allEntries = computed(() => {
+  return lessons.value.map(lesson => {
+    const sections = []
+    let assessmentCount = 0
+    let totalItems = 0
+    let learnedItems = 0
+    const itemsSeen = new Set()
+
+    lesson.sections.forEach((section, sIdx) => {
+      const examples = []
+
+      section.examples.forEach((example, eIdx) => {
+        // Count learning items
+        if (example.rel) {
+          example.rel.forEach(item => {
+            const id = item[0]
+            if (!itemsSeen.has(id)) {
+              itemsSeen.add(id)
+              totalItems++
+              if (isItemLearned(learning.value, teaching.value, id)) {
+                learnedItems++
+              }
+            }
+          })
+        }
+
+        // Only show assessment-type examples
+        const type = example.type || 'qa'
+        if (type === 'qa') return
+
+        assessmentCount++
+        const saved = getAnswer(learning.value, teaching.value, lesson.number, sIdx, eIdx)
+
+        examples.push({
+          key: `${sIdx}-${eIdx}`,
+          question: example.q,
+          type,
+          answered: !!saved,
+          correct: saved?.correct ?? null,
+          displayAnswer: formatSavedAnswer(saved, example),
+          expected: saved?.correct === false ? formatExpectedAnswer(example) : null
+        })
+      })
+
+      if (examples.length > 0) {
+        sections.push({
+          index: sIdx,
+          title: section.title,
+          examples
+        })
+      }
+    })
+
+    return {
+      lesson,
+      sections,
+      assessmentCount,
+      totalItems,
+      learnedItems
+    }
+  })
+})
+
+// Filter by selected lesson
+const filteredEntries = computed(() => {
+  if (selectedLesson.value === null) return allEntries.value
+  return allEntries.value.filter(e => e.lesson.number === selectedLesson.value)
+})
+
+// Aggregate totals (based on filtered view)
+const totalAssessments = computed(() => filteredEntries.value.reduce((sum, e) => sum + e.assessmentCount, 0))
+const totalAnswered = computed(() => filteredEntries.value.reduce((sum, e) =>
+  sum + e.sections.reduce((s, sec) => s + sec.examples.filter(ex => ex.answered).length, 0), 0))
+const totalCorrect = computed(() => filteredEntries.value.reduce((sum, e) =>
+  sum + e.sections.reduce((s, sec) => s + sec.examples.filter(ex => ex.correct === true).length, 0), 0))
+const totalWrong = computed(() => filteredEntries.value.reduce((sum, e) =>
+  sum + e.sections.reduce((s, sec) => s + sec.examples.filter(ex => ex.correct === false).length, 0), 0))
+const totalUnanswered = computed(() => totalAssessments.value - totalAnswered.value)
+const totalLearnedItems = computed(() => filteredEntries.value.reduce((sum, e) => sum + e.learnedItems, 0))
+
+// Generate plain-text report (uses filtered view)
+function generateReport() {
+  const lines = []
+  const topicName = formatLangName(teaching.value)
+  const date = new Date().toISOString().slice(0, 10)
+
+  lines.push(`Open Learn - Assessment Results`)
+  lines.push(`Topic: ${topicName}`)
+  lines.push(`Date: ${date}`)
+  lines.push('')
+
+  for (const entry of filteredEntries.value) {
+    lines.push(`Lesson ${entry.lesson.number}: ${entry.lesson.title}`)
+    if (entry.totalItems > 0) {
+      lines.push(`  Learned items: ${entry.learnedItems}/${entry.totalItems}`)
+    }
+
+    if (entry.assessmentCount === 0) {
+      lines.push('  No assessments')
+    } else {
+      const answered = entry.sections.reduce((s, sec) => s + sec.examples.filter(ex => ex.answered).length, 0)
+      const correct = entry.sections.reduce((s, sec) => s + sec.examples.filter(ex => ex.correct === true).length, 0)
+      lines.push(`  Assessments: ${answered}/${entry.assessmentCount} answered, ${correct} correct`)
+    }
+
+    for (const section of entry.sections) {
+      lines.push(`  Section: ${section.title}`)
+      for (const ex of section.examples) {
+        if (ex.answered) {
+          const mark = ex.correct === true ? 'ok' : ex.correct === false ? '!!' : '--'
+          let line = `    [${mark}] ${ex.question} -> ${ex.displayAnswer}`
+          if (ex.expected) line += ` (expected: ${ex.expected})`
+          lines.push(line)
+        } else {
+          lines.push(`    [  ] ${ex.question} -> (not answered)`)
+        }
+      }
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+// Build mailto: link
+const mailtoLink = computed(() => {
+  if (!coachEmail.value) return '#'
+  const topicName = formatLangName(teaching.value)
+  const subject = `Assessment Results - ${topicName}`
+  const body = generateReport()
+  return `mailto:${encodeURIComponent(coachEmail.value)}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
+})
+
+// Format a saved answer for display
+function formatSavedAnswer(saved, example) {
+  if (!saved) return ''
+  const type = saved.type || example.type || 'qa'
+
+  if (type === 'input') {
+    return saved.answer
+  }
+  if (type === 'select' && example.options) {
+    return example.options[saved.answer]?.text || String(saved.answer)
+  }
+  if (type === 'multiple-choice' && example.options && Array.isArray(saved.answer)) {
+    return saved.answer.map(i => example.options[i]?.text || String(i)).join(', ')
+  }
+  return String(saved.answer)
+}
+
+// Format expected answer for display (on incorrect)
+function formatExpectedAnswer(example) {
+  const type = example.type || 'qa'
+  if (type === 'input') {
+    return Array.isArray(example.a) ? example.a[0] : example.a
+  }
+  if (type === 'select' && example.options) {
+    const idx = example.options.findIndex(o => o.correct)
+    return idx >= 0 ? example.options[idx].text : null
+  }
+  if (type === 'multiple-choice' && example.options) {
+    return example.options.filter(o => o.correct).map(o => o.text).join(', ')
+  }
+  return null
+}
+
+async function loadData() {
+  if (!learning.value || !teaching.value) return
+  isLoading.value = true
+  lessons.value = await loadAllLessonsForTopic(learning.value, teaching.value)
+  isLoading.value = false
+  emit('update-title', 'Results')
+}
+
+watch([learning, teaching], () => {
+  loadData()
+}, { immediate: true })
+</script>

--- a/src/views/LessonsOverview.vue
+++ b/src/views/LessonsOverview.vue
@@ -36,6 +36,15 @@
       </div>
     </div>
 
+    <!-- Assessment results link -->
+    <div v-if="!isLoading && lessons.length > 0" class="mt-6">
+      <router-link
+        :to="`/${learning}/${teaching}/results`"
+        class="inline-block px-5 py-3 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-lg font-semibold hover:bg-gray-300 dark:hover:bg-gray-600 transition">
+        Assessment Results
+      </router-link>
+    </div>
+
     <!-- Loading state -->
     <div v-else-if="isLoading" class="text-center py-8">
       <div class="text-2xl font-bold text-primary-500 dark:text-blue-400 mb-4">

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -178,47 +178,6 @@
     </div>
     </div>
 
-    <!-- Workshop Section -->
-    <div class="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg">
-      <h2 class="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-6 pb-3 border-b-2 border-gray-300 dark:border-gray-600">
-        Workshop
-      </h2>
-
-      <!-- Coach Consent Toggle -->
-      <div class="mb-6">
-        <label class="block font-semibold text-gray-800 dark:text-gray-200 mb-2 text-lg">
-          Share Answers with Coach
-        </label>
-        <div class="text-gray-600 dark:text-gray-400 text-sm mb-3">
-          Allow sending your assessment answers to the workshop coach's server.
-          This only applies to lessons that have a coach configured.
-        </div>
-        <label class="relative inline-block w-14 h-8 cursor-pointer">
-          <input
-            type="checkbox"
-            v-model="settings.coachConsent"
-            class="opacity-0 w-0 h-0 peer" />
-          <span
-            class="absolute cursor-pointer top-0 left-0 right-0 bottom-0 bg-gray-300 dark:bg-gray-600 transition rounded-full peer-checked:bg-primary-500 before:content-[''] before:absolute before:h-6 before:w-6 before:left-1 before:bottom-1 before:bg-white before:transition before:rounded-full peer-checked:before:translate-x-6">
-          </span>
-        </label>
-      </div>
-
-      <!-- Coach Identifier -->
-      <div v-if="settings.coachConsent" class="mb-6">
-        <label class="block font-semibold text-gray-800 dark:text-gray-200 mb-2 text-lg">
-          Your Name or Email (optional)
-        </label>
-        <div class="text-gray-600 dark:text-gray-400 text-sm mb-3">
-          Identify yourself to the coach. Leave empty for anonymous submissions.
-        </div>
-        <input
-          type="text"
-          v-model="settings.coachIdentifier"
-          class="w-full p-2 border rounded bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200"
-          placeholder="your@email.com or username" />
-      </div>
-    </div>
     <!-- Data Section -->
     <div class="bg-gray-100 dark:bg-gray-800 p-6 rounded-lg">
       <h2 class="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-6 pb-3 border-b-2 border-gray-300 dark:border-gray-600">

--- a/tests/coach-forwarding.test.js
+++ b/tests/coach-forwarding.test.js
@@ -1,154 +1,30 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { useAssessments } from '../src/composables/useAssessments'
 
-describe('Coach Answer Forwarding (Batch)', () => {
+describe('Coach queue removal', () => {
   let assessments
 
   beforeEach(() => {
     localStorage.clear()
     assessments = useAssessments()
     assessments.assessments.value = {}
-    assessments.coachQueue.value = []
-    global.fetch = vi.fn()
   })
 
-  afterEach(() => {
-    vi.restoreAllMocks()
+  it('does not export coach queue functions', () => {
+    expect(assessments.coachQueue).toBeUndefined()
+    expect(assessments.queueForCoach).toBeUndefined()
+    expect(assessments.flushCoachQueue).toBeUndefined()
+    expect(assessments.flushCoachQueueSync).toBeUndefined()
+    expect(assessments.clearCoachQueue).toBeUndefined()
+    expect(assessments.hasQueuedAnswers).toBeUndefined()
   })
 
-  describe('queueForCoach', () => {
-    it('adds an answer to the queue', () => {
-      assessments.queueForCoach(
-        { learning: 'en', teaching: 'test', number: 1 },
-        { section: { index: 0 }, answer: { value: 'test' } }
-      )
-      expect(assessments.coachQueue.value).toHaveLength(1)
-      expect(assessments.hasQueuedAnswers()).toBe(true)
-    })
-
-    it('accumulates multiple answers', () => {
-      const ctx = { learning: 'en', teaching: 'test', number: 1 }
-      assessments.queueForCoach(ctx, { answer: { value: 'a' } })
-      assessments.queueForCoach(ctx, { answer: { value: 'b' } })
-      assessments.queueForCoach(ctx, { answer: { value: 'c' } })
-      expect(assessments.coachQueue.value).toHaveLength(3)
-    })
-  })
-
-  describe('flushCoachQueue', () => {
-    it('does not flush when consent is disabled', async () => {
-      assessments.queueForCoach({ learning: 'en' }, { answer: { value: 'test' } })
-      const result = await assessments.flushCoachQueue(
-        { api: 'https://coach.example.com/api' },
-        { coachConsent: false, coachIdentifier: '' }
-      )
-      expect(result).toBeNull()
-      expect(fetch).not.toHaveBeenCalled()
-    })
-
-    it('does not flush when queue is empty', async () => {
-      const result = await assessments.flushCoachQueue(
-        { api: 'https://coach.example.com/api' },
-        { coachConsent: true, coachIdentifier: '' }
-      )
-      expect(result).toBeNull()
-      expect(fetch).not.toHaveBeenCalled()
-    })
-
-    it('does not flush when no coach API configured', async () => {
-      assessments.queueForCoach({ learning: 'en' }, { answer: { value: 'test' } })
-      const result = await assessments.flushCoachQueue(
-        null,
-        { coachConsent: true, coachIdentifier: '' }
-      )
-      expect(result).toBeNull()
-      expect(fetch).not.toHaveBeenCalled()
-    })
-
-    it('sends batched answers and clears queue', async () => {
-      fetch.mockResolvedValue({ ok: true })
-
-      const ctx = { learning: 'en', teaching: 'test', number: 1, title: 'Test' }
-      assessments.queueForCoach(ctx, { answer: { value: 'a' } })
-      assessments.queueForCoach(ctx, { answer: { value: 'b' } })
-
-      const result = await assessments.flushCoachQueue(
-        { api: 'https://coach.example.com/api' },
-        { coachConsent: true, coachIdentifier: '' }
-      )
-
-      expect(result).toEqual({ ok: true, count: 2 })
-      expect(assessments.coachQueue.value).toHaveLength(0)
-
-      const body = JSON.parse(fetch.mock.calls[0][1].body)
-      expect(body.answers).toHaveLength(2)
-      expect(body.lesson).toEqual(ctx)
-      expect(body.timestamp).toBeDefined()
-    })
-
-    it('includes user identifier when provided', async () => {
-      fetch.mockResolvedValue({ ok: true })
-
-      assessments.queueForCoach({ learning: 'en' }, { answer: { value: 'test' } })
-      await assessments.flushCoachQueue(
-        { api: 'https://coach.example.com/api' },
-        { coachConsent: true, coachIdentifier: 'user@test.com' }
-      )
-
-      const body = JSON.parse(fetch.mock.calls[0][1].body)
-      expect(body.user).toBe('user@test.com')
-    })
-
-    it('omits user field when identifier is empty', async () => {
-      fetch.mockResolvedValue({ ok: true })
-
-      assessments.queueForCoach({ learning: 'en' }, { answer: { value: 'test' } })
-      await assessments.flushCoachQueue(
-        { api: 'https://coach.example.com/api' },
-        { coachConsent: true, coachIdentifier: '' }
-      )
-
-      const body = JSON.parse(fetch.mock.calls[0][1].body)
-      expect(body.user).toBeUndefined()
-    })
-
-    it('returns enrollUrl on 401 response', async () => {
-      fetch.mockResolvedValue({
-        ok: false,
-        status: 401,
-        json: () => Promise.resolve({ enrollUrl: 'https://workshop.example.com/enroll' })
-      })
-
-      assessments.queueForCoach({ learning: 'en' }, { answer: { value: 'test' } })
-      const result = await assessments.flushCoachQueue(
-        { api: 'https://coach.example.com/api' },
-        { coachConsent: true, coachIdentifier: '' }
-      )
-
-      expect(result).toEqual({ ok: false, enrollUrl: 'https://workshop.example.com/enroll' })
-    })
-
-    it('returns null on network error', async () => {
-      fetch.mockRejectedValue(new Error('Network error'))
-
-      assessments.queueForCoach({ learning: 'en' }, { answer: { value: 'test' } })
-      const result = await assessments.flushCoachQueue(
-        { api: 'https://coach.example.com/api' },
-        { coachConsent: true, coachIdentifier: '' }
-      )
-
-      expect(result).toBeNull()
-    })
-  })
-
-  describe('clearCoachQueue', () => {
-    it('clears the queue', () => {
-      assessments.queueForCoach({ learning: 'en' }, { answer: { value: 'test' } })
-      expect(assessments.hasQueuedAnswers()).toBe(true)
-
-      assessments.clearCoachQueue()
-      expect(assessments.hasQueuedAnswers()).toBe(false)
-      expect(assessments.coachQueue.value).toHaveLength(0)
-    })
+  it('still exports core assessment functions', () => {
+    expect(assessments.getAnswer).toBeInstanceOf(Function)
+    expect(assessments.saveAnswer).toBeInstanceOf(Function)
+    expect(assessments.validateAnswer).toBeInstanceOf(Function)
+    expect(assessments.clearAnswers).toBeInstanceOf(Function)
+    expect(assessments.getAssessments).toBeInstanceOf(Function)
+    expect(assessments.mergeAssessments).toBeInstanceOf(Function)
   })
 })


### PR DESCRIPTION
Remove the POST-based coach forwarding system (queue, batch send, sendBeacon,
consent settings) and replace with a new Assessment Results page that shows
all lessons with learned items stats, assessment answers, and missing
assignments. Sending results opens a mailto: link to the coach's email
with a plain-text report. Coach config changes from api URL to email address.

https://claude.ai/code/session_012TaCbZvwHWHMA9zBGPMgjb